### PR TITLE
Refactored player delete functionality

### DIFF
--- a/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
+++ b/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
@@ -9,8 +9,10 @@ import at.aau.serg.websocketserver.mapper.PlayerMapper;
 import at.aau.serg.websocketserver.service.GameLobbyEntityService;
 import at.aau.serg.websocketserver.service.PlayerEntityService;
 import at.aau.serg.websocketserver.statuscode.ErrorCode;
+import at.aau.serg.websocketserver.statuscode.ResponseCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityExistsException;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
@@ -243,19 +245,38 @@ public class PlayerController {
         }
     }
 
-    // TODO: handle deletion of player inside a lobby properly?
     @MessageMapping("/player-delete")
-    @SendToUser("/queue/player-response")
+    @SendToUser("/queue/response")
     public String handleDeletePlayer(String playerDtoJson) throws JsonProcessingException {
         PlayerDto playerDto = objectMapper.readValue(playerDtoJson, PlayerDto.class);
 
         playerEntityService.deletePlayer(playerDto.getId());
-        Optional<PlayerEntity> shouldBeEmpty = playerEntityService.findPlayerById(playerDto.getId());
-        if (shouldBeEmpty.isEmpty()) {
-            return "DELETED";
-        } else {
-            throw new RuntimeException("player was not deleted");
+
+        Optional<PlayerEntity> playerEntity = playerEntityService.findPlayerById(playerDto.getId());
+        if (playerEntity.isPresent()) {
+            throw new EntityExistsException(ErrorCode.ERROR_2006.getErrorCode());
         }
+
+        // Update logic if a player was part of a lobby
+        if(playerDto.getGameLobbyId() != null) {
+            Optional<GameLobbyEntity> gameLobbyEntityOptional = gameLobbyEntityService.findById(playerDto.getGameLobbyId());
+            if(gameLobbyEntityOptional.isPresent()) {
+                GameLobbyEntity gameLobbyEntity = gameLobbyEntityOptional.get();
+                // send response to: /topic/lobby-$id --> updated list of players in lobby (later with response code: 201)
+                this.template.convertAndSend(
+                        "/topic/lobby-" + gameLobbyEntity.getId(),
+                        objectMapper.writeValueAsString(getPlayerDtosInLobbyList(gameLobbyEntity.getId(), gameLobbyEntityService, playerEntityService, playerMapper))
+                );
+            } else {
+                // send response to: /topic/lobby-list --> updated list of lobbies (later with response code 301)
+                this.template.convertAndSend(
+                        "/topic/lobby-list",
+                        objectMapper.writeValueAsString(getGameLobbyDtoList(gameLobbyEntityService, gameLobbyMapper))
+                );
+            }
+        }
+
+        return ResponseCode.RESPONSE_103.getResponseCode();
     }
 
     @MessageExceptionHandler

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
@@ -142,12 +142,19 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
 
     @Override
     public void deletePlayer(Long id) {
-        playerEntityRepository.deleteById(id);
+        Optional<PlayerEntity> playerEntityOptional = playerEntityRepository.findById(id);
+        if(playerEntityOptional.isPresent()) {
+            PlayerEntity playerEntity = playerEntityOptional.get();
+            GameLobbyEntity gameLobbyEntity = playerEntity.getGameLobbyEntity();
+
+            if(gameLobbyEntity != null) {
+                leaveLobby(playerEntity);
+            }
+            playerEntityRepository.deleteById(id);
+        } else {
+            throw new EntityNotFoundException(ErrorCode.ERROR_2001.getErrorCode());
+        }
     }
-    // alternative suggestion:
-//    public void deletePlayer(PlayerEntity playerEntity) {
-//        playerEntityRepository.delete(playerEntity);
-//    }
 
 
 

--- a/src/main/java/at/aau/serg/websocketserver/statuscode/ErrorCode.java
+++ b/src/main/java/at/aau/serg/websocketserver/statuscode/ErrorCode.java
@@ -11,10 +11,11 @@ public enum ErrorCode {
     ERROR_2002("player with the id already exists", "2002"),
     ERROR_2003("player with the username already exists", "2003"),
     ERROR_2004("invalid playerDto JSON", "2004"),
-    ERROR_2005("player is not in a gameLobby", "2005");
+    ERROR_2005("player is not in a gameLobby", "2005"),
+    ERROR_2006("player still exists", "2006");
+
     private final String errorDescription;
     private final String errorCode;
-
 
     /**
      * Enum of standardized custom response codes.

--- a/src/main/java/at/aau/serg/websocketserver/statuscode/ResponseCode.java
+++ b/src/main/java/at/aau/serg/websocketserver/statuscode/ResponseCode.java
@@ -3,6 +3,7 @@ package at.aau.serg.websocketserver.statuscode;
 public enum ResponseCode {
     RESPONSE_101("received updated playerDto", "101"),
     RESPONSE_102("placeholder", "102"),
+    RESPONSE_103("player successfully deleted", "103"),
     RESPONSE_201("received updated list of players in the current lobby", "201"),
     RESPONSE_202("received updated name of current lobby", "202"),
     RESPONSE_203("lobby was deleted", "203"),

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameLobbyControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameLobbyControllerIntegrationTest.java
@@ -324,7 +324,7 @@ public class GameLobbyControllerIntegrationTest {
 
     @Test
     void testThatUpdateLobbyNameFails() throws Exception {
-        StompSession session = initStompSessionWithErrorTopic("/topic/game-lobby-response", "/user/queue/errors", messages);
+        StompSession session = initStompSessionWithSecondTopic("/topic/game-lobby-response", "/user/queue/errors", messages);
 
         GameLobbyDto gameLobbyDto = TestDataUtil.createTestGameLobbyDtoA();
         gameLobbyEntityService.createLobby(gameLobbyMapper.mapToEntity(gameLobbyDto));
@@ -405,7 +405,7 @@ public class GameLobbyControllerIntegrationTest {
         return session;
     }
 
-    public StompSession initStompSessionWithErrorTopic(String topic, String errorTopic, BlockingQueue<String> messages) throws Exception {
+    public StompSession initStompSessionWithSecondTopic(String topic, String errorTopic, BlockingQueue<String> messages) throws Exception {
         StompSession session = initStompSession(topic, messages);
         session.subscribe(errorTopic, new StompFrameHandlerClientImpl(messages));
 


### PR DESCRIPTION
1) It is now checked if the requested player exists, if not an exception is thrown
2) It is checked if the player is part of a lobby, if he is then he is removed from the lobby first before deletion
All others players are notified that the player leaves as in handlePlayerLeaveLobby
3) If the player is the only one in a lobby, the lobby and the player are deleted (leaveLobby is used for that)
All players are notified of the deleted Lobby as in handlePlayerLeaveLobby

In case of success Response Code RESPONSE_103 (player successfully deleted) is returned
In case of an exception Error Codes ERROR_2006 (player still exists), ERROR_2001 (player with the id does not exist) or exceptions from the leaveLobby Method are returned to the error queue