### PR TITLE
Tile Deck implementation on the server side

### DIFF
--- a/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
+++ b/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
@@ -9,10 +9,8 @@ import at.aau.serg.websocketserver.mapper.PlayerMapper;
 import at.aau.serg.websocketserver.service.GameLobbyEntityService;
 import at.aau.serg.websocketserver.service.PlayerEntityService;
 import at.aau.serg.websocketserver.statuscode.ErrorCode;
-import at.aau.serg.websocketserver.statuscode.ResponseCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityExistsException;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
@@ -228,14 +226,11 @@ public class PlayerController {
                     objectMapper.writeValueAsString(getPlayerDtosInLobbyList(gameLobbyId, gameLobbyEntityService, playerEntityService, playerMapper))
             );
 
-            // TODO: test
-            if (gameLobbyEntityService.findById(gameLobbyId).isPresent()){
-                // send updated gameLobbyDto to all players in the lobby (relevant for lobbyCreator)
-                this.template.convertAndSend(
-                        "/topic/lobby-" + gameLobbyId + "/update",
-                        objectMapper.writeValueAsString(gameLobbyMapper.mapToDto(gameLobbyEntityService.findById(gameLobbyId).get()))
-                );
-            }
+            // send updated gameLobbyDto to all players in the lobby (relevant for lobbyCreator)
+            this.template.convertAndSend(
+                    "/topic/lobby-" + gameLobbyId + "/update",
+                    objectMapper.writeValueAsString(gameLobbyMapper.mapToDto(gameLobbyEntityService.findById(gameLobbyId).get()))
+            );
 
             // send response to: /user/queue/response --> updated playerDto (later with response code: 101)
             return objectMapper.writeValueAsString(playerMapper.mapToDto(updatedPlayerEntity));
@@ -245,6 +240,7 @@ public class PlayerController {
         }
     }
 
+    // TODO: handle deletion of player inside a lobby properly?
     @MessageMapping("/player-delete")
     @SendToUser("/queue/response")
     public String handleDeletePlayer(String playerDtoJson) throws JsonProcessingException {

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/GroundType.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/GroundType.java
@@ -2,10 +2,10 @@ package at.aau.serg.websocketserver.domain.dto;
 
 public enum GroundType {
 
-    CASTLE,
-    ROAD,
-    MONASTERY,
-    FIELDS,
-    OTHER;
+//    CASTLE,
+//    ROAD,
+//    MONASTERY,
+//    FIELDS,
+//    OTHER;
 
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/GroundType.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/GroundType.java
@@ -1,0 +1,11 @@
+package at.aau.serg.websocketserver.domain.dto;
+
+public enum GroundType {
+
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/NextTurnDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/NextTurnDto.java
@@ -1,0 +1,15 @@
+package at.aau.serg.websocketserver.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NextTurnDto {
+    Long playerId;
+    Long tileId;
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerColour.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerColour.java
@@ -1,10 +1,10 @@
 package at.aau.serg.websocketserver.domain.dto;
 
 public enum PlayerColour {
-    BLACK,
-    RED,
-    BLUE,
-    GREEN,
-    YELLOW
+//    BLACK,
+//    RED,
+//    BLUE,
+//    GREEN,
+//    YELLOW
 
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerColour.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerColour.java
@@ -1,0 +1,10 @@
+package at.aau.serg.websocketserver.domain.dto;
+
+public enum PlayerColour {
+    BLACK,
+    RED,
+    BLUE,
+    GREEN,
+    YELLOW
+
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/TileDeckDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/TileDeckDto.java
@@ -1,0 +1,18 @@
+package at.aau.serg.websocketserver.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * DTO for {@link at.aau.serg.websocketserver.domain.entity.TileDeckEntity}
+ */
+@Value
+@Builder
+public class TileDeckDto implements Serializable {
+    Long id;
+    List<Long> tileId;
+    Long gameSessionId;
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/TileDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/TileDto.java
@@ -1,0 +1,24 @@
+package at.aau.serg.websocketserver.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TileDto {
+
+    private Long id;
+
+//    private String tileName;
+//
+//    private String northEdgeType;
+//    private String southEdgeType;
+//    private String eastEdgeType;
+//    private String westEdgeType;
+//
+//    private int rotation;
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/TileType.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/TileType.java
@@ -1,0 +1,58 @@
+package at.aau.serg.websocketserver.domain.dto;
+
+import static at.aau.serg.websocketserver.domain.dto.GroundType.*;
+
+public enum TileType {
+//    Null(0, OTHER, OTHER, OTHER, OTHER, OTHER, OTHER, OTHER, OTHER, OTHER),
+//    CastleCenter(1, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE),
+//    CastleCenterEntry(3, CASTLE, CASTLE, ROAD, CASTLE, CASTLE, FIELDS, FIELDS, CASTLE, CASTLE),
+//    CastleCenterSide(4, CASTLE, CASTLE, FIELDS, CASTLE, CASTLE, FIELDS, FIELDS, CASTLE, CASTLE),
+//    CastleEdge(5, CASTLE, CASTLE, FIELDS, FIELDS, CASTLE, FIELDS, FIELDS, FIELDS, FIELDS),
+//    CastleEdgeRoad(4, CASTLE, CASTLE, ROAD, ROAD, CASTLE, FIELDS, FIELDS, FIELDS, ROAD),
+//    CastleSides(3, CASTLE, FIELDS, CASTLE, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS),
+//    CastleSidesEdge(2, CASTLE, FIELDS, FIELDS, CASTLE, FIELDS, FIELDS, FIELDS, OTHER, FIELDS),
+//    CastleTube(2, FIELDS, CASTLE, FIELDS, CASTLE, FIELDS, FIELDS, FIELDS, FIELDS, CASTLE),
+//    CastleWall(5, CASTLE, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS),
+//    CastleWallCurveLeft(3, CASTLE, FIELDS, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    CastleWallCurveRight(3, CASTLE, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    CastleWallJunction(3, CASTLE, ROAD, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, OTHER),
+//    CastleWallRoad(4, CASTLE, ROAD, FIELDS, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    Monastery(4, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, MONASTERY),
+//    MonasteryRoad(2, FIELDS, FIELDS, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, MONASTERY),
+//    Road(7, ROAD, FIELDS, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    RoadCurve(8, FIELDS, FIELDS, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    RoadJunctionLarge(1, ROAD, ROAD, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, OTHER),
+//    RoadJunctionSmall(3, FIELDS, ROAD, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, OTHER),
+//    RoadCrossLarge(0, ROAD, ROAD, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    RoadCrossSmall(2, FIELDS, ROAD, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    CastleTubeEntries(1, ROAD, CASTLE, ROAD, CASTLE, FIELDS, FIELDS, FIELDS, FIELDS, CASTLE),
+//    CastleTubeEntry(1, FIELDS, CASTLE, ROAD, CASTLE, FIELDS, FIELDS, FIELDS, FIELDS, CASTLE),
+//    MonasteryCastle(1, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, CASTLE, MONASTERY),
+//    MonasteryJunction(1, ROAD, ROAD, ROAD, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, MONASTERY),
+//    CastleSidesRoad(2, CASTLE, ROAD, CASTLE, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    CastleSidesEdgeRoad(1, CASTLE, ROAD, ROAD, CASTLE, FIELDS, FIELDS, FIELDS, OTHER, ROAD),
+//    CastleSidesQuad(1, CASTLE, CASTLE, CASTLE, CASTLE, OTHER, OTHER, OTHER, OTHER, FIELDS),
+//    RoadEnd(1, FIELDS, FIELDS, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, OTHER),
+//    CastleCenterSides(1, FIELDS, FIELDS, CASTLE, FIELDS, OTHER, OTHER, OTHER, OTHER, CASTLE),
+//    CastleMini(1, FIELDS, FIELDS, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, CASTLE),
+//    CastleWallEntryLeft(1, CASTLE, FIELDS, FIELDS, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    CastleWallEntryRight(1, CASTLE, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, ROAD),
+//    CastleWallEntry(2, CASTLE, FIELDS, ROAD, FIELDS, FIELDS, FIELDS, FIELDS, FIELDS, ROAD);
+//
+//    private final GroundType[] groundTypes;
+//    private final int amount;
+//    TileType(int amount, GroundType... groundTypes) {
+//        this.amount = amount;
+//        this.groundTypes = groundTypes;
+//    }
+//
+//    public GroundType[] getGroundTypes() {
+//        return groundTypes;
+//    }
+//
+//    public int getAmount() {
+//        return amount;
+//    }
+
+
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/GameSessionEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/GameSessionEntity.java
@@ -1,6 +1,5 @@
 package at.aau.serg.websocketserver.domain.entity;
 
-import at.aau.serg.websocketserver.domain.dto.GameState;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,4 +21,11 @@ public class GameSessionEntity {
     private Long turnPlayerId;
     private String gameState;
     private List<Long> playerIds;
+
+    // One-to-one relationship with TileDeckEntity
+//    @OneToOne(cascade = CascadeType.ALL)
+//    @JoinColumn(name = "tiledeck_id", unique = true)
+//    @EqualsAndHashCode.Exclude
+    @OneToOne(mappedBy = "gameSession", cascade = CascadeType.ALL, orphanRemoval = true)
+    private TileDeckEntity tileDeck;
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/PlayerEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/PlayerEntity.java
@@ -23,4 +23,10 @@ public class PlayerEntity {
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name="gamelobby_id")
     private GameLobbyEntity gameLobbyEntity;
+
+    private int points;
+
+    private boolean isMyTurn;
+
+    private String playerColour;
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/TileDeckEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/TileDeckEntity.java
@@ -26,7 +26,6 @@ public class TileDeckEntity {
 //    @ElementCollection(targetClass = Long.class)
     private List<Long> tileId;
 
-
     // One-to-one relationship with GameSessionEntity
     //    @OneToOne(mappedBy = "tileDeck")
     @OneToOne

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/TileDeckEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/TileDeckEntity.java
@@ -1,0 +1,35 @@
+package at.aau.serg.websocketserver.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+//https://stackoverflow.com/questions/34972895/lombok-hashcode-issue-with-java-lang-stackoverflowerror-null
+// might help! if there is a recursive StackOverflow error change Lombok @Data to @Getter and @Setter
+//weird Lombok circular dependency issue
+//@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "tiledeck")
+public class TileDeckEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tiledeck_id_seq")
+    private Long id;
+
+    //DOCU: https://www.baeldung.com/java-jpa-persist-string-list
+//    @ElementCollection(targetClass = Long.class)
+    private List<Long> tileId;
+
+
+    // One-to-one relationship with GameSessionEntity
+    //    @OneToOne(mappedBy = "tileDeck")
+    @OneToOne
+    @JoinColumn(name = "game_session_id", unique = true)
+    private GameSessionEntity gameSession;
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/TileEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/TileEntity.java
@@ -1,0 +1,32 @@
+package at.aau.serg.websocketserver.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "tile")
+public class TileEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tile_id_seq")
+    private Long id;
+
+//    private String tileName;
+//    private String northEdgeType;
+//    private String southEdgeType;
+//    private String eastEdgeType;
+//    private String westEdgeType;
+//
+//    private TileType tileType;
+//
+////    Rotation is defined from 0 to 4 (0 north points to north)
+//    private int rotation;
+
+    //TODO: maybe need to add more attributes
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/GameSessionEntityRepository.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/GameSessionEntityRepository.java
@@ -1,16 +1,8 @@
 package at.aau.serg.websocketserver.domain.entity.repository;
 
-<<<<<<< HEAD
+
 import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-=======
-import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
-import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
-
->>>>>>> amadeo_implement_card_tile_deck_backend
 public interface GameSessionEntityRepository extends JpaRepository<GameSessionEntity, Long> {
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/GameSessionEntityRepository.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/GameSessionEntityRepository.java
@@ -1,7 +1,16 @@
 package at.aau.serg.websocketserver.domain.entity.repository;
 
+<<<<<<< HEAD
 import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+=======
+import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
+import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+>>>>>>> amadeo_implement_card_tile_deck_backend
 public interface GameSessionEntityRepository extends JpaRepository<GameSessionEntity, Long> {
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/TileDeckRepository.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/TileDeckRepository.java
@@ -1,0 +1,11 @@
+package at.aau.serg.websocketserver.domain.entity.repository;
+
+import at.aau.serg.websocketserver.domain.entity.TileDeckEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TileDeckRepository extends JpaRepository<TileDeckEntity, Long> {
+    TileDeckEntity findByGameSessionId(Long gameSessionId);
+
+}

--- a/src/main/java/at/aau/serg/websocketserver/mapper/TileDeckMapper.java
+++ b/src/main/java/at/aau/serg/websocketserver/mapper/TileDeckMapper.java
@@ -1,0 +1,26 @@
+package at.aau.serg.websocketserver.mapper;
+
+import at.aau.serg.websocketserver.domain.dto.TileDeckDto;
+import at.aau.serg.websocketserver.domain.dto.TileDto;
+import at.aau.serg.websocketserver.domain.entity.TileDeckEntity;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TileDeckMapper {
+    private final ModelMapper modelMapper;
+
+
+    public TileDeckMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    //    Amadeo
+    public TileDeckDto mapToDto(TileDeckEntity tileDeckEntity) {
+        return modelMapper.map(tileDeckEntity, TileDeckDto.class);
+    }
+
+    public TileDeckEntity mapToEntity(TileDto tileDto) {
+        return modelMapper.map(tileDto, TileDeckEntity.class);
+    }
+}

--- a/src/main/java/at/aau/serg/websocketserver/service/GameSessionEntityService.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/GameSessionEntityService.java
@@ -9,4 +9,8 @@ import java.util.Optional;
 public interface GameSessionEntityService {
     GameSessionEntity createGameSession(Long gameLobbyId) throws EntityExistsException;
     Optional<GameSessionEntity> findById(Long id) throws EntityNotFoundException;
+
+    Long calculateNextPlayer(Long gameSessionId);
+
+    GameSessionEntity terminateGameSession(Long gameSessionId);
 }

--- a/src/main/java/at/aau/serg/websocketserver/service/TileDeckEntityService.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/TileDeckEntityService.java
@@ -1,0 +1,19 @@
+package at.aau.serg.websocketserver.service;
+
+import at.aau.serg.websocketserver.domain.entity.TileDeckEntity;
+
+import java.util.List;
+
+public interface TileDeckEntityService {
+    TileDeckEntity createTileDeck(Long gameSessionId);
+
+    List<Long> generateTileIds();
+
+    Long drawNextTile(TileDeckEntity tileDeck);
+
+    boolean isTileDeckEmpty(TileDeckEntity tileDeck);
+
+    void resetTileDeck(Long gameSessionId);
+
+    List<Long> getAllTilesInDeck(Long gameSessionId);
+}

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
@@ -119,7 +119,7 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
         }
 
         playerEntity.setGameLobbyEntity(null);
-        playerEntityRepository.save(playerEntity);
+        PlayerEntity updatedPlayerEntity =  playerEntityRepository.save(playerEntity);
 
         // Check if lobby can be deleted
         int numberOfPlayers = gameLobbyEntity.getNumPlayers();
@@ -137,7 +137,7 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
         } else {
             gameLobbyEntityRepository.deleteById(gameLobbyEntity.getId());
         }
-        return playerEntity;
+        return updatedPlayerEntity;
     }
 
     @Override

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/TileDeckEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/TileDeckEntityServiceImpl.java
@@ -1,0 +1,139 @@
+package at.aau.serg.websocketserver.service.impl;
+
+import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
+import at.aau.serg.websocketserver.domain.entity.TileDeckEntity;
+import at.aau.serg.websocketserver.domain.entity.repository.GameSessionEntityRepository;
+import at.aau.serg.websocketserver.domain.entity.repository.TileDeckRepository;
+import at.aau.serg.websocketserver.service.TileDeckEntityService;
+import at.aau.serg.websocketserver.statuscode.ErrorCode;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TileDeckEntityServiceImpl implements TileDeckEntityService {
+    TileDeckRepository tileDeckRepository;
+    GameSessionEntityRepository gameSessionEntityRepository;
+
+
+    public TileDeckEntityServiceImpl(TileDeckRepository tileDeckRepository,
+                                     GameSessionEntityRepository gameSessionEntityRepository) {
+        this.tileDeckRepository = tileDeckRepository;
+        this.gameSessionEntityRepository = gameSessionEntityRepository;
+    }
+
+    /**
+     * Create a new tile deck entity for the given game session ID.
+     *
+     * @param gameSessionId The ID of the game session for which the tile deck entity should be created.
+     * @return The created tile deck entity.
+     * @throws EntityNotFoundException If the game session entity does not exist for the given game session ID.
+     */
+
+    @Override
+    public TileDeckEntity createTileDeck(Long gameSessionId) {
+        Optional<GameSessionEntity> gameSessionOptional = gameSessionEntityRepository.findById(gameSessionId);
+
+        if (gameSessionOptional.isPresent()) {
+            GameSessionEntity gameSession = gameSessionOptional.get();
+
+//            Create a new tile deck entity
+            TileDeckEntity tileDeck = new TileDeckEntity();
+            tileDeck.setTileId(generateTileIds());
+            tileDeck.setGameSession(gameSession);
+
+//            Return the created tile deck entity
+            return tileDeckRepository.save(tileDeck);
+        } else {
+            throw new EntityNotFoundException(ErrorCode.ERROR_3003.getErrorCode());
+        }
+    }
+
+    /**
+     * Generate a list of tile IDs for a new tile deck.
+     *
+     * @return A list of tile IDs.
+     */
+
+    @Override
+    public List<Long> generateTileIds() {
+        List<Long> tileIds = new ArrayList<>();
+        for (Long i = 0L; i <= 71L; i++) {
+            tileIds.add(i);
+        }
+        Collections.shuffle(tileIds);
+        return tileIds;
+    }
+
+/**
+     * Draw the next tile from the tile deck.
+     *
+     * @param tileDeck The tile deck from which the next tile should be drawn.
+     * @return The ID of the drawn tile.
+     * @throws IllegalStateException If the tile deck is empty.
+     */
+
+    @Override
+    public Long drawNextTile(TileDeckEntity tileDeck) {
+        List<Long> tileIds = tileDeck.getTileId();
+        if (tileIds.isEmpty()) {
+            throw new IllegalStateException("No more tile left in the deck."); // No more tiles left in the deck
+        }
+        Long drawnTileId = tileIds.remove(0); // Remove and return the first tile from the deck
+        tileDeck.setTileId(tileIds); // Update the tile deck in the database
+        tileDeckRepository.save(tileDeck);
+        return drawnTileId;
+    }
+
+    /**
+     * Check if the tile deck is empty.
+     *
+     * @param tileDeck The tile deck to check.
+     * @return True if the tile deck is empty, false otherwise.
+     */
+
+    @Override
+    public boolean isTileDeckEmpty(TileDeckEntity tileDeck) {
+        return tileDeck.getTileId().isEmpty();
+    }
+
+    @Override
+//    TODO: Implement the resetTileDeck method if needed
+    public void resetTileDeck(Long gameSessionId) {
+//        // Retrieve the tile deck entity for the given game session ID
+//        TileDeckEntity tileDeckEntity = tileDeckRepository.findByGameSessionId(gameSessionId);
+//
+//        if (tileDeckEntity != null) {
+//            // Retrieve all tiles from the database
+//            List<TileDeckEntity> allTiles = tileDeckRepository.findAll();
+//
+//            // Extract the IDs of all tiles
+//            List<Long> tileIds = new ArrayList<>();
+//            for (TileEntity tile : allTiles) {
+//                tileIds.add(tile.getId());
+//            }
+//
+//            // Update the tile deck entity with the new list of tile IDs
+//            tileDeckEntity.setTileId(tileIds);
+//
+//            // Save the updated tile deck entity
+//            tileDeckRepository.save(tileDeckEntity);
+//        } else {
+//            // Handle case where tile deck entity does not exist for the given game session ID
+//            // (Optional: you can throw an exception or log a message)
+//        }
+//    }
+    }
+//TODO implement this method
+
+    @Override
+    public List<Long> getAllTilesInDeck(Long gameSessionId) {
+        return null;
+    }
+
+}
+

--- a/src/main/java/at/aau/serg/websocketserver/statuscode/ErrorCode.java
+++ b/src/main/java/at/aau/serg/websocketserver/statuscode/ErrorCode.java
@@ -12,10 +12,12 @@ public enum ErrorCode {
     ERROR_2003("player with the username already exists", "2003"),
     ERROR_2004("invalid playerDto JSON", "2004"),
     ERROR_2005("player is not in a gameLobby", "2005"),
-    ERROR_2006("player still exists", "2006");
+    ERROR_2006("player still exists", "2006"),
+    ERROR_3003("gameSession with the id does not exist", "3003");
 
     private final String errorDescription;
     private final String errorCode;
+
 
     /**
      * Enum of standardized custom response codes.

--- a/src/test/java/at/aau/serg/websocketserver/TestDataUtil.java
+++ b/src/test/java/at/aau/serg/websocketserver/TestDataUtil.java
@@ -1,10 +1,8 @@
 package at.aau.serg.websocketserver;
 
-import at.aau.serg.websocketserver.domain.dto.GameLobbyDto;
-import at.aau.serg.websocketserver.domain.dto.GameSessionDto;
-import at.aau.serg.websocketserver.domain.dto.GameState;
-import at.aau.serg.websocketserver.domain.dto.PlayerDto;
+import at.aau.serg.websocketserver.domain.dto.*;
 import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
+import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
 import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
 
 import java.sql.Timestamp;
@@ -133,6 +131,23 @@ public class TestDataUtil {
                 .turnPlayerId(lobbyCreator.getId())
                 .gameState(GameState.IN_GAME)
                 .playerIds(null)
+                .build();
+    }
+
+    public static GameSessionEntity createTestGameSessionEntityA(PlayerEntity lobbyCreator) {
+        return GameSessionEntity.builder()
+                .id(1L)
+                .turnPlayerId(lobbyCreator.getId())
+                .gameState(GameState.IN_GAME.toString())
+                .playerIds(null)
+                .build();
+    }
+
+    public static TileDeckDto createTestTileDeckDtoA(Long gameSessionId) {
+        return TileDeckDto.builder()
+                .id(1L)
+                .tileId(null)
+                .gameSessionId(gameSessionId)
                 .build();
     }
 }

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
@@ -5,13 +5,20 @@ import at.aau.serg.websocketserver.demo.websocket.StompFrameHandlerClientImpl;
 import at.aau.serg.websocketserver.domain.dto.GameLobbyDto;
 import at.aau.serg.websocketserver.domain.dto.GameSessionDto;
 import at.aau.serg.websocketserver.domain.dto.GameState;
+import at.aau.serg.websocketserver.domain.dto.NextTurnDto;
 import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
+import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
 import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
+import at.aau.serg.websocketserver.domain.entity.TileDeckEntity;
+import at.aau.serg.websocketserver.domain.entity.repository.GameLobbyEntityRepository;
+import at.aau.serg.websocketserver.domain.entity.repository.GameSessionEntityRepository;
+import at.aau.serg.websocketserver.domain.entity.repository.TileDeckRepository;
 import at.aau.serg.websocketserver.mapper.GameLobbyMapper;
 import at.aau.serg.websocketserver.mapper.PlayerMapper;
 import at.aau.serg.websocketserver.service.GameLobbyEntityService;
 import at.aau.serg.websocketserver.service.GameSessionEntityService;
 import at.aau.serg.websocketserver.service.PlayerEntityService;
+import at.aau.serg.websocketserver.service.impl.TileDeckEntityServiceImpl;
 import at.aau.serg.websocketserver.statuscode.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
@@ -48,30 +55,49 @@ public class GameSessionControllerIntegrationTest {
     private final GameSessionEntityService gameSessionEntityService;
     private final GameLobbyEntityService gameLobbyEntityService;
     private final PlayerEntityService playerEntityService;
+    private final TileDeckEntityServiceImpl tileDeckEntityService;
+    private final TileDeckRepository tileDeckRepository;
+
 
     @Autowired
-    public GameSessionControllerIntegrationTest(ObjectMapper objectMapper, GameLobbyMapper gameLobbyMapper, PlayerMapper playerMapper, GameSessionEntityService gameSessionEntityService, GameLobbyEntityService gameLobbyEntityService, PlayerEntityService playerEntityService) {
+    public GameSessionControllerIntegrationTest(ObjectMapper objectMapper, GameLobbyMapper gameLobbyMapper, PlayerMapper playerMapper, GameSessionEntityService gameSessionEntityService, GameLobbyEntityService gameLobbyEntityService, PlayerEntityService playerEntityService, TileDeckEntityServiceImpl tileDeckEntityService, TileDeckRepository tileDeckRepository) {
         this.objectMapper = objectMapper;
         this.gameLobbyMapper = gameLobbyMapper;
         this.playerMapper = playerMapper;
         this.gameSessionEntityService = gameSessionEntityService;
         this.gameLobbyEntityService = gameLobbyEntityService;
         this.playerEntityService = playerEntityService;
+        this.tileDeckEntityService = tileDeckEntityService;
+        this.tileDeckRepository = tileDeckRepository;
     }
 
     @LocalServerPort
     private int port;
     private final String WEBSOCKET_URI = "ws://localhost:%d/websocket-broker";
     BlockingQueue<String> messages;
+    BlockingQueue<String> messages2;
+    BlockingQueue<String> messages3;
+    BlockingQueue<String> messages4;
+    @Autowired
+    private GameSessionEntityRepository gameSessionEntityRepository;
+    @Autowired
+    private GameLobbyEntityRepository gameLobbyEntityRepository;
+
 
     @BeforeEach
     public void setUp() {
         messages = new LinkedBlockingDeque<>();
+        messages2 = new LinkedBlockingDeque<>();
+        messages3 = new LinkedBlockingDeque<>();
+        messages4 = new LinkedBlockingDeque<>();
     }
 
     @AfterEach
     public void tearDown() {
         messages = null;
+        messages2 = null;
+        messages3 = null;
+        messages4 = null;
     }
 
     @Test
@@ -153,6 +179,447 @@ public class GameSessionControllerIntegrationTest {
 
         assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
         assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void testThatGetNextPlayerIdAndNextTileIdReturnsTheRightNextPlayerId() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+        GameLobbyDto gameLobbyDtoB = TestDataUtil.createTestGameLobbyDtoB();
+        GameLobbyEntity gameLobbyEntityB = gameLobbyMapper.mapToEntity(gameLobbyDtoB);
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+        gameLobbyEntityB.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        gameLobbyEntityService.createLobby(gameLobbyEntityB);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoB.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+        List<GameLobbyDto> gameLobbyDtoList = new ArrayList<>();
+        gameLobbyDtoA.setGameState(GameState.IN_GAME);
+        gameLobbyDtoA.setLobbyAdminId(playerEntityA.getId());
+        gameLobbyDtoA.setNumPlayers(3);
+        gameLobbyDtoList.add(gameLobbyDtoA);
+
+        gameLobbyDtoB.setLobbyAdminId(playerEntityA.getId());
+        gameLobbyDtoList.add(gameLobbyDtoB);
+
+        String expectedResponse = objectMapper.writeValueAsString(gameLobbyDtoList);
+        String actualResponse = messages.poll(1, TimeUnit.SECONDS);
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+        assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponseGameSessionEntity);
+
+        StompSession session2 = initStompSession("/user/queue/next-turn-response", messages3);
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+
+        Long expectedResponseNextPlayerId = playerEntityB.getId();
+        String actualResponseNextTurnDto = messages3.poll(1, TimeUnit.SECONDS);
+        NextTurnDto result = objectMapper.readValue(actualResponseNextTurnDto, NextTurnDto.class);
+
+        assertThat(result.getPlayerId()).isEqualTo(expectedResponseNextPlayerId);
+    }
+    @Test
+    void testThatGetNextPlayerIdAndNextTileIdReturnsTheRightNextTile() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+
+//        Get the TileDeck from the gameSession
+        TileDeckEntity tileDeck = tileDeckRepository.findByGameSessionId(gameSessionDtoA.getId());
+        assertThat(tileDeck).isNotNull();
+
+        List<Long> firstTile = tileDeck.getTileId();
+
+//      Subscribe to the topic for the next turn
+        StompSession session2 = initStompSession("/user/queue/next-turn-response", messages3);
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+//
+//      Receive the next turn dto from the endpoint
+        Long expectedFirstTile = firstTile.get(0);
+        String actualResponseNextTurnDto = messages3.poll(1, TimeUnit.SECONDS);
+        NextTurnDto result = objectMapper.readValue(actualResponseNextTurnDto, NextTurnDto.class);
+//
+//      Extract the next player id
+        assertThat(result.getTileId()).isEqualTo(expectedFirstTile);
+    }
+
+    @Test
+    void testThatGameInFinishedStateThrowsException() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+//        Create gameSessionEntity
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+        assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponseGameSessionEntity);
+
+//        Set the gameSessionEntity to finished
+        GameSessionEntity gameSession = gameSessionEntityService.findById(gameSessionDtoA.getId()).get();
+        gameSession.setGameState(GameState.FINISHED.name());
+        gameSessionEntityRepository.save(gameSession);
+
+        StompSession session2 = initStompSession("/user/queue/errors", messages3);
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+
+        String expectedResponse = "ERROR: " + "Game is already finished.";
+        String actualResponse = messages3.poll(1, TimeUnit.SECONDS);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+    @Test
+    void testThatGameSessionControllerThrowsExceptionIfTheGameSessionIsDeleted() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+//        Create gameSessionEntity
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+        assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponseGameSessionEntity);
+
+        StompSession session2 = initStompSession("/user/queue/errors", messages3);
+
+//        Delete the gameSessionEntity
+        gameSessionEntityRepository.deleteById(gameSessionDtoA.getId());
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+
+        String expectedResponse = "ERROR: " + "GameSession not found.";
+        String actualResponse = messages3.poll(1, TimeUnit.SECONDS);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+    @Test
+    void testThatGameSessionControllerThrowsExceptionIfTheWrongGameSessionIdIsSupplied() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+//        Create gameSessionEntity
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+        assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponseGameSessionEntity);
+
+        StompSession session2 = initStompSession("/user/queue/errors", messages3);
+
+//        Provide the gameSessionEntityId that does not exist
+        session2.send("/app/next-turn", 2L + "");
+
+        String expectedResponse = "ERROR: " + "GameSession not found.";
+        String actualResponse = messages3.poll(1, TimeUnit.SECONDS);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void testThatGameTerminatesIfTheDeckIsEmpty() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+//        Create gameSessionEntity
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+        assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponseGameSessionEntity);
+
+//        Find the deck and set it to empty deck
+        TileDeckEntity tileDeck = tileDeckRepository.findByGameSessionId(gameSessionDtoA.getId());
+        tileDeck.setTileId(new ArrayList<>());
+        tileDeckRepository.save(tileDeck);
+
+        StompSession session2 = initStompSession("/user/queue/next-turn-response", messages3);
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+
+        String expectedResponse = "FINISHED";
+        String actualResponse = messages3.poll(1, TimeUnit.SECONDS);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+    @Test
+    void testThatGameTerminatesIfTheDeckIsEmptyAndSendsTheMessageToTheTopic() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+//        Create gameSessionEntity
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+        assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponseGameSessionEntity);
+
+//        Find the deck and set it to empty deck
+        TileDeckEntity tileDeck = tileDeckRepository.findByGameSessionId(gameSessionDtoA.getId());
+        tileDeck.setTileId(new ArrayList<>());
+        tileDeckRepository.save(tileDeck);
+
+        StompSession session2 = initStompSession("/user/queue/next-turn-response", messages3);
+//        Subscribe to topic for the game state finish
+        StompSession session3 = initStompSession("/topic/game-session-" + gameLobbyDtoA.getId() + "/game-finished", messages4);
+//        Try to draw a tile
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+
+        String expectedResponse = "FINISHED";
+        String actualResponse = messages3.poll(1, TimeUnit.SECONDS);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+
+        String expectedResponseTopic = "FINISHED";
+        String actualResponseTopic = messages4.poll(1, TimeUnit.SECONDS);
+
+        assertThat(actualResponseTopic).isEqualTo(expectedResponseTopic);
+    }
+
+    @Test
+    void testThatGameTerminatesWhenTheDeckIsEmptyAfterDrawingLastCard() throws Exception {
+        GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
+        GameLobbyEntity gameLobbyEntityA = gameLobbyMapper.mapToEntity(gameLobbyDtoA);
+
+        PlayerEntity playerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity playerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        PlayerEntity playerEntityC = TestDataUtil.createTestPlayerEntityC(null);
+        gameLobbyEntityA.setLobbyAdminId(playerEntityA.getId());
+
+        playerEntityService.createPlayer(playerEntityA);
+        playerEntityService.createPlayer(playerEntityB);
+        playerEntityService.createPlayer(playerEntityC);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyDtoA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
+
+        GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
+
+//        Create gameSessionEntity
+        StompSession session = initStompSession("/user/queue/lobby-list-response", messages);
+        initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages2);
+        session.send("/app/game-start", gameLobbyDtoA.getId() + "");
+
+//        Get the expected GameSessionEntity
+        String expectedResponseGameSessionEntity = objectMapper.writeValueAsString(gameSessionDtoA.getId());
+        String actualResponseGameSessionEntity = messages2.poll(1, TimeUnit.SECONDS);
+
+        assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
+        assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponseGameSessionEntity);
+
+//        Find the deck and set it to the deck with one last tile
+        TileDeckEntity tileDeck = tileDeckRepository.findByGameSessionId(gameSessionDtoA.getId());
+        List<Long> lastTile = new ArrayList<>();
+        lastTile.add(71L);
+        tileDeck.setTileId(lastTile);
+        tileDeckRepository.save(tileDeck);
+
+        StompSession session2 = initStompSession("/user/queue/next-turn-response", messages3);
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+
+        String actualResponseBeforeDeckEmpty = messages3.poll(1, TimeUnit.SECONDS);
+        NextTurnDto resultBeforeDeckEmpty = objectMapper.readValue(actualResponseBeforeDeckEmpty, NextTurnDto.class);
+        NextTurnDto expectedBeforeDeckEmpty = new NextTurnDto(playerEntityB.getId(), 71L);
+
+        assertThat(resultBeforeDeckEmpty).isEqualTo(expectedBeforeDeckEmpty);
+
+//        Now the deck is empty
+        tileDeck = tileDeckRepository.findByGameSessionId(gameSessionDtoA.getId());
+        List<Long> expectedEmptyDeck = new ArrayList<>();
+        List<Long> actualEmptyDeck = tileDeck.getTileId();
+
+        assertThat(actualEmptyDeck).isEqualTo(expectedEmptyDeck);
+
+//        Draw another tile
+        session2.send("/app/next-turn", gameSessionDtoA.getId() + "");
+
+//        Now we check if the user gets the right gameState message string
+        String expectedResponse = "FINISHED";
+        String actualResponse = messages3.poll(1, TimeUnit.SECONDS);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+//
+//        Now the gameState should be set to finished
+        String expectedGameState = "FINISHED";
+        String actualGameState = gameSessionEntityService.findById(gameSessionDtoA.getId()).get().getGameState();
+
+        assertThat(actualGameState).isEqualTo(expectedGameState);
     }
 
     @Test

--- a/src/test/java/at/aau/serg/websocketserver/controller/PlayerControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/PlayerControllerIntegrationTest.java
@@ -1059,7 +1059,6 @@ public class PlayerControllerIntegrationTest {
         testPlayerEntityA.setGameLobbyEntity(testGameLobbyEntityA);
 
         StompSession session = initStompSession("/user/queue/response", messages);
-        StompSession session2 = initStompSession("/topic/lobby-" + testGameLobbyEntityA.getId() + "/update", messages2);
 
         testGameLobbyEntityA.setNumPlayers(1);
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId())).isEmpty();
@@ -1079,16 +1078,14 @@ public class PlayerControllerIntegrationTest {
         session.send("/app/player-leave-lobby", payload);
 
         String actualResponse = messages.poll(1, TimeUnit.SECONDS);
-        String actualResponse2 = messages2.poll(1, TimeUnit.SECONDS);
 
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getId()).isEmpty()).isTrue();
         testPlayerEntityA.setGameLobbyEntity(null);
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
 
         testPlayerDtoA.setGameLobbyId(null);
-        var expectedResponse = objectMapper.writeValueAsString(testPlayerDtoA);
+        String expectedResponse = objectMapper.writeValueAsString(testPlayerDtoA);
         assertThat(actualResponse).isEqualTo(expectedResponse);
-        assertThat(actualResponse2).isEqualTo(null);
     }
 
     @Test

--- a/src/test/java/at/aau/serg/websocketserver/service/TileDeckEntityServiceImplTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/service/TileDeckEntityServiceImplTest.java
@@ -1,0 +1,118 @@
+package at.aau.serg.websocketserver.service;
+
+import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
+import at.aau.serg.websocketserver.domain.entity.TileDeckEntity;
+import at.aau.serg.websocketserver.domain.entity.repository.TileDeckRepository;
+import at.aau.serg.websocketserver.service.impl.TileDeckEntityServiceImpl;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+class TileDeckEntityServiceImplTest {
+
+
+    @Mock
+    private TileDeckRepository tileDeckRepository;
+    @Mock
+    private GameSessionEntityService gameSessionEntityService;
+    @InjectMocks
+    private TileDeckEntityServiceImpl tileDeckEntityService;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+//    @Test
+//    void createTileDeck() {
+//        // Arrange
+//        Long gameSessionId = 1L; // replace with the actual gameSessionId you want to use
+//
+//        // Mock the behavior of gameSessionEntityService.findById method
+//        GameSessionEntity gameSessionEntity = new GameSessionEntity();
+//        gameSessionEntity.setId(gameSessionId);
+//        when(gameSessionEntityService.findById(gameSessionId)).thenReturn(Optional.of(gameSessionEntity));
+//
+//        // Mock the behavior of tileDeckRepository.save method
+//        TileDeckEntity tileDeck = new TileDeckEntity();
+//        when(tileDeckRepository.save(any(TileDeckEntity.class))).thenReturn(tileDeck);
+//
+//        // Act
+//        TileDeckEntity result = tileDeckEntityService.createTileDeck(gameSessionId);
+//
+//        // Assert
+//        assertNotNull(result);
+//        verify(tileDeckRepository, times(1)).save(any(TileDeckEntity.class));
+//    }
+
+//    @Test
+//    void createTileDeck_EntityNotFoundException() {
+//        // Arrange
+//        Long gameSessionId = 1L; // replace with the actual gameSessionId you want to use
+//
+//        // Mock the behavior of gameSessionEntityService.findById method to return an empty Optional
+//        when(gameSessionEntityService.findById(gameSessionId)).thenReturn(Optional.empty());
+//
+//        // Act and Assert
+//        assertThrows(EntityNotFoundException.class, () -> {
+//            tileDeckEntityService.createTileDeck(gameSessionId);
+//        });
+//    }
+
+    @Test
+    void drawNextTile() {
+        // Arrange
+        List<Long> tileIds = new ArrayList<>(Arrays.asList(1L, 2L, 3L));
+        TileDeckEntity tileDeck = new TileDeckEntity();
+        tileDeck.setTileId(tileIds);
+
+        // Mock the behavior of tileDeckRepository.save method
+        when(tileDeckRepository.save(any(TileDeckEntity.class))).thenReturn(tileDeck);
+
+        // Act
+        Long result = tileDeckEntityService.drawNextTile(tileDeck);
+
+        // Assert
+        assertEquals(1L, result);
+        assertEquals(2, tileDeck.getTileId().size());
+        verify(tileDeckRepository, times(1)).save(tileDeck);
+    }
+
+    @Test
+    void drawNextTile_EmptyDeck_ThrowsException() {
+        // Arrange
+        TileDeckEntity tileDeck = new TileDeckEntity();
+        tileDeck.setTileId(new ArrayList<>()); // Set the tileId list as an empty list
+
+        // Act
+//        Long result = tileDeckEntityService.drawNextTile(tileDeck);
+
+        // Assert
+        assertThrows(IllegalStateException.class, () -> tileDeckEntityService.drawNextTile(tileDeck));
+    }
+
+//    TODO: Add more tests
+
+}


### PR DESCRIPTION
Add the Tile Deck Entity to the backend, which generates a list of the tileIds, shuffles them and stores them in a database.

In the gameSessionControler, it sends the next user (queue) the playerId and tileId to user.

If the deck is empty it terminates the game and sends all the users (topic/ dedicated to gameSession) the updated gameState.

It also encompasses all the tests with above 90% coverage.