### PR TITLE
fix: generate the TileIds from 1L to 71L and test it

### DIFF
--- a/src/main/java/at/aau/serg/websocketserver/service/impl/TileDeckEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/TileDeckEntityServiceImpl.java
@@ -63,7 +63,7 @@ public class TileDeckEntityServiceImpl implements TileDeckEntityService {
     @Override
     public List<Long> generateTileIds() {
         List<Long> tileIds = new ArrayList<>();
-        for (Long i = 0L; i <= 71L; i++) {
+        for (Long i = 1L; i <= 71L; i++) {
             tileIds.add(i);
         }
         Collections.shuffle(tileIds);

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(SpringExtension.class)
@@ -327,6 +328,7 @@ public class GameSessionControllerIntegrationTest {
 //        Get the TileDeck from the gameSession
         TileDeckEntity tileDeck = tileDeckRepository.findByGameSessionId(gameSessionDtoA.getId());
         assertThat(tileDeck).isNotNull();
+        assertFalse(tileDeck.getTileId().contains(0L), "TileDeck should not contain 0L as a value");
 
         List<Long> firstTile = tileDeck.getTileId();
 


### PR DESCRIPTION
fix the deck generating so that it generates the IDs from 1L to 71L, to avoid sending a 0L, which is already placed in the gameboard