### PR TITLE
fix: h2 console is now enabled

### DIFF
--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/PlacedTileDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/PlacedTileDto.java
@@ -22,7 +22,7 @@ public class PlacedTileDto {
     // Tile id
     private Long tileId;
 
-    // tile rotation
+    // tile coordinates
     private Coordinates coordinates;
 
     // tile rotation

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,4 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-
+spring.h2.console.enabled=true


### PR DESCRIPTION
h2 console can now be used to access the h2 database in the browser via:
localhost:8080/h2-console