### PR TITLE
Added PlayerColour Assignment logic

### DIFF
--- a/src/main/java/at/aau/serg/websocketserver/controller/GameLobbyController.java
+++ b/src/main/java/at/aau/serg/websocketserver/controller/GameLobbyController.java
@@ -78,12 +78,15 @@ public class GameLobbyController {
                 String updatedLobbyList = objectMapper.writeValueAsString(getGameLobbyDtoList(gameLobbyEntityService, gameLobbyMapper));
                 this.template.convertAndSend("/topic/lobby-list", updatedLobbyList);
 
+                // TODO
                 // send updated list of players in lobby to /topic/lobby-$id
                 // IMPORTANT: not relevant, as player does not know the lobby id when calling lobby-create
                 String updatedPlayerList = objectMapper.writeValueAsString(getPlayerDtosInLobbyList(createdGameLobbyEntity.getId(), gameLobbyEntityService, playerEntityService, playerMapper));
                 this.template.convertAndSend("/topic/lobby-" + createdGameLobbyEntity.getId(), updatedPlayerList);
 
-                // return updated playerDto to queue
+                // TODO: Add gamelobbyId in the future
+                this.template.convertAndSend("/topic/lobby-creator", playerMapper.mapToDto(playerEntity));
+
                 return objectMapper.writeValueAsString(gameLobbyMapper.mapToDto(playerEntity.getGameLobbyEntity()));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(ErrorCode.ERROR_2004.getErrorCode());

--- a/src/main/java/at/aau/serg/websocketserver/controller/GameLobbyController.java
+++ b/src/main/java/at/aau/serg/websocketserver/controller/GameLobbyController.java
@@ -85,7 +85,7 @@ public class GameLobbyController {
                 this.template.convertAndSend("/topic/lobby-" + createdGameLobbyEntity.getId(), updatedPlayerList);
 
                 // TODO: Add gamelobbyId in the future
-                this.template.convertAndSend("/topic/lobby-creator", playerMapper.mapToDto(playerEntity));
+                this.template.convertAndSend("/topic/lobby-creator", objectMapper.writeValueAsString(playerMapper.mapToDto(playerEntity)));
 
                 return objectMapper.writeValueAsString(gameLobbyMapper.mapToDto(playerEntity.getGameLobbyEntity()));
             } catch (JsonProcessingException e) {

--- a/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
+++ b/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
@@ -95,7 +95,6 @@ public class PlayerController {
 
             // 3) player joins lobby:
             PlayerEntity updatedPlayerEntity = playerEntityService.joinLobby(gameLobbyId, playerEntity);
-
             PlayerDto dto = playerMapper.mapToDto(updatedPlayerEntity);
 
             // send response to /topic/lobby-$id --> updated list of players in lobby (later with response code: 201)

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/GameLobbyDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/GameLobbyDto.java
@@ -1,12 +1,14 @@
 package at.aau.serg.websocketserver.domain.dto;
 
 import at.aau.serg.websocketserver.domain.pojo.GameState;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -28,5 +30,7 @@ public class GameLobbyDto {
     private Integer numPlayers;
 
     private Long lobbyAdminId;
+
+    private List<PlayerColour> availableColours;
 }
 

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/Meeple.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/Meeple.java
@@ -1,0 +1,18 @@
+package at.aau.serg.websocketserver.domain.dto;
+
+import at.aau.serg.websocketserver.domain.pojo.Coordinates;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Meeple {
+    Long id;
+    PlayerColour color;
+    Long playerId;
+    boolean placed;
+    Coordinates coordinates;
+}

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/PlacedTileDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/PlacedTileDto.java
@@ -27,4 +27,7 @@ public class PlacedTileDto {
 
     // tile rotation
     private Integer rotation;
+
+    // Meeple
+    private Meeple placedMeeple;
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerDto.java
@@ -1,5 +1,6 @@
 package at.aau.serg.websocketserver.domain.dto;
 
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,5 +17,6 @@ public class PlayerDto {
 
     //private GameLobbyDto gameLobbyDto;
     private Long gameLobbyId;
+    private PlayerColour playerColour;
 
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/GameLobbyEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/GameLobbyEntity.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -30,4 +32,5 @@ public class GameLobbyEntity {
     private Integer numPlayers;
 
     private Long lobbyAdminId;
+    private List<String> availableColours;
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/GameLobbyEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/GameLobbyEntity.java
@@ -1,5 +1,6 @@
 package at.aau.serg.websocketserver.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,5 +33,6 @@ public class GameLobbyEntity {
     private Integer numPlayers;
 
     private Long lobbyAdminId;
+
     private List<String> availableColours;
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/pojo/PlayerColour.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/pojo/PlayerColour.java
@@ -1,9 +1,18 @@
 package at.aau.serg.websocketserver.domain.pojo;
 
+import java.util.Arrays;
+import java.util.List;
+
 public enum PlayerColour {
     BLACK,
     RED,
     BLUE,
     GREEN,
-    YELLOW
+    YELLOW;
+
+    public static List<String> getColoursAsList() {
+        return Arrays.stream(PlayerColour.values())
+                .map(Enum::toString)
+                .toList();
+    }
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/pojo/PlayerColour.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/pojo/PlayerColour.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 public enum PlayerColour {
     BLACK,
-    RED,
     BLUE,
     GREEN,
+    RED,
     YELLOW;
 
     public static List<String> getColoursAsList() {

--- a/src/main/java/at/aau/serg/websocketserver/domain/pojo/PlayerColour.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/pojo/PlayerColour.java
@@ -1,10 +1,9 @@
 package at.aau.serg.websocketserver.domain.pojo;
 
 public enum PlayerColour {
-//    BLACK,
-//    RED,
-//    BLUE,
-//    GREEN,
-//    YELLOW
-
+    BLACK,
+    RED,
+    BLUE,
+    GREEN,
+    YELLOW
 }

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/GameLobbyEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/GameLobbyEntityServiceImpl.java
@@ -3,6 +3,7 @@ package at.aau.serg.websocketserver.service.impl;
 import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
 import at.aau.serg.websocketserver.domain.entity.repository.GameLobbyEntityRepository;
 import at.aau.serg.websocketserver.domain.entity.repository.PlayerEntityRepository;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
 import at.aau.serg.websocketserver.statuscode.ErrorCode;
 import at.aau.serg.websocketserver.service.GameLobbyEntityService;
 import jakarta.persistence.EntityExistsException;
@@ -39,6 +40,7 @@ public class GameLobbyEntityServiceImpl implements GameLobbyEntityService {
         }
 
         gameLobbyEntity.setNumPlayers(0);
+        gameLobbyEntity.setAvailableColours(PlayerColour.getColoursAsList());
         return gameLobbyEntityRepository.save(gameLobbyEntity);
     }
 

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
@@ -13,6 +13,7 @@ import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -24,7 +25,7 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
     GameLobbyEntityRepository gameLobbyEntityRepository;
     GameLobbyMapper gameLobbyMapper;
     PlayerMapper playerMapper;
-    Random random;
+    SecureRandom random;
 
     public PlayerEntityServiceImpl(
             PlayerEntityRepository playerEntityRepository,
@@ -36,7 +37,7 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
         this.gameLobbyEntityRepository = gameLobbyEntityRepository;
         this.gameLobbyMapper = gameLobbyMapper;
         this.playerMapper = playerMapper;
-        this.random = new Random();
+        this.random = new SecureRandom();
     }
 
     private void setPlayerColour(PlayerEntity playerEntity, GameLobbyEntity gameLobbyEntity) {

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 @Service
 public class PlayerEntityServiceImpl implements PlayerEntityService {
@@ -89,6 +90,16 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
 
         // update the PlayerEntity's gameLobby property to reference the gameLobbyEntity which should be joined
         playerEntity.setGameLobbyEntity(gameLobbyEntity);
+
+        // Randomly assign player colour
+        List<String> colours = gameLobbyEntity.getAvailableColours();
+
+        Random random = new Random();
+        int randomIndex = random.nextInt(colours.size());
+        playerEntity.setPlayerColour(colours.get(randomIndex));
+        colours.remove(randomIndex);
+        gameLobbyEntity.setAvailableColours(colours);
+
         // update the numPlayers property of the gameLobbyEntity by 1
         gameLobbyEntity.setNumPlayers(gameLobbyEntity.getNumPlayers()+1);
         gameLobbyEntityRepository.save(gameLobbyEntity);

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
@@ -24,6 +24,7 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
     GameLobbyEntityRepository gameLobbyEntityRepository;
     GameLobbyMapper gameLobbyMapper;
     PlayerMapper playerMapper;
+    Random random;
 
     public PlayerEntityServiceImpl(
             PlayerEntityRepository playerEntityRepository,
@@ -35,12 +36,12 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
         this.gameLobbyEntityRepository = gameLobbyEntityRepository;
         this.gameLobbyMapper = gameLobbyMapper;
         this.playerMapper = playerMapper;
+        this.random = new Random();
     }
 
     private void setPlayerColour(PlayerEntity playerEntity, GameLobbyEntity gameLobbyEntity) {
         List<String> colours = gameLobbyEntity.getAvailableColours();
 
-        Random random = new Random();
         int randomIndex = random.nextInt(colours.size());
         playerEntity.setPlayerColour(colours.get(randomIndex));
         colours.remove(randomIndex);

--- a/src/test/java/at/aau/serg/websocketserver/TestDataUtil.java
+++ b/src/test/java/at/aau/serg/websocketserver/TestDataUtil.java
@@ -6,6 +6,7 @@ import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
 import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
 import at.aau.serg.websocketserver.domain.pojo.Coordinates;
 import at.aau.serg.websocketserver.domain.pojo.GameState;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ public class TestDataUtil {
                 .id(1L)
                 .username("usernameA")
                 .gameLobbyEntity(gameLobbyEntity)
+                .playerColour(null)
                 .build();
     }
 
@@ -36,6 +38,7 @@ public class TestDataUtil {
                 .id(2L)
                 .username("usernameB")
                 .gameLobbyEntity(gameLobbyEntity)
+                .playerColour(null)
                 .build();
     }
 
@@ -49,6 +52,7 @@ public class TestDataUtil {
                 .id(3L)
                 .username("usernameC")
                 .gameLobbyEntity(gameLobbyEntity)
+                .playerColour(null)
                 .build();
     }
     public static PlayerEntity createTestPlayerEntityD(final GameLobbyEntity gameLobbyEntity){
@@ -56,6 +60,7 @@ public class TestDataUtil {
                 .id(null)
                 .username("usernameD")
                 .gameLobbyEntity(gameLobbyEntity)
+                .playerColour(null)
                 .build();
     }
     public static PlayerEntity createTestPlayerEntityE(final GameLobbyEntity gameLobbyEntity){
@@ -63,6 +68,7 @@ public class TestDataUtil {
                 .id(null)
                 .username("usernameE")
                 .gameLobbyEntity(gameLobbyEntity)
+                .playerColour(null)
                 .build();
     }
     public static PlayerEntity createTestPlayerEntityF(final GameLobbyEntity gameLobbyEntity){
@@ -70,6 +76,7 @@ public class TestDataUtil {
                 .id(null)
                 .username("usernameF")
                 .gameLobbyEntity(gameLobbyEntity)
+                .playerColour(null)
                 .build();
     }
 
@@ -78,6 +85,7 @@ public class TestDataUtil {
                 .id(null)
                 .username("usernameG")
                 .gameLobbyEntity(gameLobbyEntity)
+                .playerColour(null)
                 .build();
     }
 
@@ -90,6 +98,7 @@ public class TestDataUtil {
                 .gameStartTimestamp(timeStamp)
                 .gameState(GameState.LOBBY.toString())
                 .numPlayers(0)
+                .availableColours(getTestPlayerColoursAsStringList())
                 .build();
     }
 
@@ -101,6 +110,7 @@ public class TestDataUtil {
                 .gameStartTimestamp(timeStamp)
                 .gameState(GameState.LOBBY.toString())
                 .numPlayers(0)
+                .availableColours(getTestPlayerColoursAsStringList())
                 .build();
     }
 
@@ -112,6 +122,7 @@ public class TestDataUtil {
                 .gameStartTimestamp(timeStamp)
                 .gameState(GameState.LOBBY.toString())
                 .numPlayers(0)
+                .availableColours(getTestPlayerColoursAsStringList())
                 .build();
     }
 
@@ -121,6 +132,7 @@ public class TestDataUtil {
                 .id(1L)
                 .username("usernameA")
                 .gameLobbyId(gameLobbyId)
+                .playerColour(null)
                 .build();
     }
 
@@ -132,6 +144,7 @@ public class TestDataUtil {
                 .gameStartTimestamp(timeStamp)
                 .gameState(GameState.LOBBY)
                 .numPlayers(0)
+                .availableColours(getTestPlayerColoursAsEnumList())
                 .build();
     }
 
@@ -143,6 +156,7 @@ public class TestDataUtil {
                 .gameStartTimestamp(timeStamp)
                 .gameState(GameState.LOBBY)
                 .numPlayers(0)
+                .availableColours(getTestPlayerColoursAsEnumList())
                 .build();
     }
 
@@ -194,5 +208,50 @@ public class TestDataUtil {
                 .coordinates(new Coordinates(12,12))
                 .rotation(1)
                 .build();
+    }
+
+    public static List<String> getTestPlayerColoursAsStringList() {
+        List<String> playerColours = new ArrayList<>();
+        playerColours.add(PlayerColour.BLACK.name());
+        playerColours.add(PlayerColour.BLUE.name());
+        playerColours.add(PlayerColour.GREEN.name());
+        playerColours.add(PlayerColour.RED.name());
+        playerColours.add(PlayerColour.YELLOW.name());
+
+        return playerColours;
+    }
+
+    public static List<PlayerColour> getTestPlayerColoursAsEnumList() {
+        List<PlayerColour> playerColours = new ArrayList<>();
+        playerColours.add(PlayerColour.BLACK);
+        playerColours.add(PlayerColour.BLUE);
+        playerColours.add(PlayerColour.GREEN);
+        playerColours.add(PlayerColour.RED);
+        playerColours.add(PlayerColour.YELLOW);
+
+        return playerColours;
+    }
+
+    public static List<String> getTestPlayerColoursAsStringListRemoveValue(String playerColour) {
+        List<String> playerColours = getTestPlayerColoursAsStringList();
+        playerColours.remove(playerColour);
+        return playerColours;
+    }
+
+    public static List<String> getTestPlayerColoursAsStringListRemoveValue(List<String> playerColours, String playerColour) {
+        playerColours.remove(playerColour);
+        return playerColours;
+    }
+
+    public static List<PlayerColour> getTestPlayerColoursAsEnumListRemoveValue(PlayerColour playerColour) {
+        List<PlayerColour> playerColours = getTestPlayerColoursAsEnumList();
+        playerColours.remove(playerColour);
+
+        return playerColours;
+    }
+
+    public static List<PlayerColour> getTestPlayerColoursAsEnumListRemoveValue(List<PlayerColour> playerColours, PlayerColour playerColour) {
+        playerColours.remove(playerColour);
+        return playerColours;
     }
 }

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameLobbyControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameLobbyControllerIntegrationTest.java
@@ -224,7 +224,6 @@ public class GameLobbyControllerIntegrationTest {
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
 
-    // TODO
     @Test
     void testThatCreateLobbyReturnsUpdatedPlayerToTopic() throws Exception {
         StompSession session = initStompSession("/topic/lobby-creator", messages);

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameLobbyControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameLobbyControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import at.aau.serg.websocketserver.domain.dto.GameLobbyDto;
 import at.aau.serg.websocketserver.domain.dto.PlayerDto;
 import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
 import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
 import at.aau.serg.websocketserver.statuscode.ErrorCode;
 import at.aau.serg.websocketserver.mapper.GameLobbyMapper;
 import at.aau.serg.websocketserver.mapper.PlayerMapper;
@@ -120,14 +121,21 @@ public class GameLobbyControllerIntegrationTest {
         session.send("/app/lobby-create", payload);
 
         gameLobbyDto.setNumPlayers(gameLobbyDto.getNumPlayers() + 1);
+        //gameLobbyDto.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumList());
         playerDto.setGameLobbyId(gameLobbyDto.getId());
 
-        String expectedResponse = objectMapper.writeValueAsString(gameLobbyDto);
         String actualResponse = messages.poll(1, TimeUnit.SECONDS);
 
         Optional<PlayerEntity> updatedPlayerEntityOptional = playerEntityService.findPlayerById(playerDto.getId());
         assertTrue(updatedPlayerEntityOptional.isPresent());
         PlayerEntity updatedPlayerEntity = updatedPlayerEntityOptional.get();
+
+        // Randomness-Workaround: Get colour from player, set all colours to lobby and remove the color from the list
+        String playerColour = updatedPlayerEntity.getPlayerColour();
+        PlayerColour playerColorEnum = PlayerColour.valueOf(playerColour);
+        gameLobbyDto.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(playerColorEnum));
+        String expectedResponse = objectMapper.writeValueAsString(gameLobbyDto);
+
         assertThat(updatedPlayerEntity.getGameLobbyEntity()).isEqualTo(gameLobbyMapper.mapToEntity(gameLobbyDto));
 
         assertThat(actualResponse).isEqualTo(expectedResponse);
@@ -161,6 +169,12 @@ public class GameLobbyControllerIntegrationTest {
         Optional<PlayerEntity> updatedPlayerEntityOptional = playerEntityService.findPlayerById(playerDto.getId());
         assertTrue(updatedPlayerEntityOptional.isPresent());
         PlayerEntity updatedPlayerEntity = updatedPlayerEntityOptional.get();
+
+        // Randomness-Workaround: Get colour from player, set all colours to lobby and remove the color from the list
+        String playerColour = updatedPlayerEntity.getPlayerColour();
+        PlayerColour playerColorEnum = PlayerColour.valueOf(playerColour);
+        gameLobbyDto.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(playerColorEnum));
+
         assertThat(updatedPlayerEntity.getGameLobbyEntity()).isEqualTo(gameLobbyMapper.mapToEntity(gameLobbyDto));
 
         String expectedResponse = objectMapper.writeValueAsString(getGameLobbyDtoList());
@@ -197,6 +211,12 @@ public class GameLobbyControllerIntegrationTest {
         Optional<PlayerEntity> updatedPlayerEntityOptional = playerEntityService.findPlayerById(playerDto.getId());
         assertTrue(updatedPlayerEntityOptional.isPresent());
         PlayerEntity updatedPlayerEntity = updatedPlayerEntityOptional.get();
+
+        // Randomness-Workaround: Get colour from player, set all colours to lobby and remove the color from the list
+        String playerColour = updatedPlayerEntity.getPlayerColour();
+        PlayerColour playerColorEnum = PlayerColour.valueOf(playerColour);
+        gameLobbyDto.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(playerColorEnum));
+
         assertThat(updatedPlayerEntity.getGameLobbyEntity()).isEqualTo(gameLobbyMapper.mapToEntity(gameLobbyDto));
 
         String expectedResponse = objectMapper.writeValueAsString(getPlayerDtosInLobbyList(gameLobbyDto.getId()));
@@ -204,6 +224,46 @@ public class GameLobbyControllerIntegrationTest {
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
 
+    // TODO
+    @Test
+    void testThatCreateLobbyReturnsUpdatedPlayerToTopic() throws Exception {
+        StompSession session = initStompSession("/topic/lobby-creator", messages);
+
+        PlayerEntity playerEntity = TestDataUtil.createTestPlayerEntityA(null);
+        playerEntityService.createPlayer(playerEntity);
+
+        PlayerDto playerDto = playerMapper.mapToDto(playerEntity);
+        GameLobbyDto gameLobbyDto = TestDataUtil.createTestGameLobbyDtoA();
+        gameLobbyDto.setLobbyAdminId(playerEntity.getId());
+
+        String playerDtoJson = objectMapper.writeValueAsString(playerDto);
+        String gameLobbyDtoJson = objectMapper.writeValueAsString(gameLobbyDto);
+
+        String payload = gameLobbyDtoJson + "|" + playerDtoJson;
+
+        assertThat(gameLobbyEntityService.findById(gameLobbyDto.getId()).isEmpty()).isTrue();
+        assertThat(playerEntityService.findPlayerById(playerDto.getId()).isPresent()).isTrue();
+        session.send("/app/lobby-create", payload);
+
+        gameLobbyDto.setNumPlayers(gameLobbyDto.getNumPlayers() + 1);
+        playerDto.setGameLobbyId(gameLobbyDto.getId());
+
+        String actualResponse = messages.poll(1, TimeUnit.SECONDS);
+
+        Optional<PlayerEntity> updatedPlayerEntityOptional = playerEntityService.findPlayerById(playerDto.getId());
+        assertTrue(updatedPlayerEntityOptional.isPresent());
+        PlayerEntity updatedPlayerEntity = updatedPlayerEntityOptional.get();
+
+        // Randomness-Workaround: Get colour from player entity and set it to player dto
+        String playerColour = updatedPlayerEntity.getPlayerColour();
+        PlayerColour playerColorEnum = PlayerColour.valueOf(playerColour);
+        playerDto.setPlayerColour(playerColorEnum);
+        String expectedResponse = objectMapper.writeValueAsString(playerDto);
+
+        assertThat(updatedPlayerEntity).isEqualTo(playerMapper.mapToEntity(playerDto));
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
 
     @Test
     void testThatCreateLobbyWithDuplicateLobbyIdFails() throws Exception {

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
@@ -14,6 +14,7 @@ import at.aau.serg.websocketserver.domain.entity.TileDeckEntity;
 import at.aau.serg.websocketserver.domain.entity.repository.GameLobbyEntityRepository;
 import at.aau.serg.websocketserver.domain.entity.repository.GameSessionEntityRepository;
 import at.aau.serg.websocketserver.domain.entity.repository.TileDeckRepository;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
 import at.aau.serg.websocketserver.mapper.GameLobbyMapper;
 import at.aau.serg.websocketserver.mapper.PlayerMapper;
 import at.aau.serg.websocketserver.service.GameLobbyEntityService;
@@ -162,6 +163,10 @@ public class GameSessionControllerIntegrationTest {
         playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
         playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
 
+        String playerEntityAColour = playerEntityService.findPlayerById(playerEntityA.getId()).get().getPlayerColour();
+        String playerEntityBColour = playerEntityService.findPlayerById(playerEntityB.getId()).get().getPlayerColour();
+        String playerEntityCColour = playerEntityService.findPlayerById(playerEntityC.getId()).get().getPlayerColour();
+
         GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
         assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
 
@@ -172,6 +177,10 @@ public class GameSessionControllerIntegrationTest {
         gameLobbyDtoA.setGameState(GameState.IN_GAME);
         gameLobbyDtoA.setLobbyAdminId(playerEntityA.getId());
         gameLobbyDtoA.setNumPlayers(3);
+
+        gameLobbyDtoA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(gameLobbyDtoA.getAvailableColours(), PlayerColour.valueOf(playerEntityAColour)));
+        gameLobbyDtoA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(gameLobbyDtoA.getAvailableColours(), PlayerColour.valueOf(playerEntityBColour)));
+        gameLobbyDtoA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(gameLobbyDtoA.getAvailableColours(), PlayerColour.valueOf(playerEntityCColour)));
         gameLobbyDtoList.add(gameLobbyDtoA);
 
         gameLobbyDtoB.setLobbyAdminId(playerEntityA.getId());
@@ -183,6 +192,7 @@ public class GameSessionControllerIntegrationTest {
         assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
+
     @Test
     void testThatFindByGameIdQueryInTileDeckEntityExecutesRight() throws Exception {
         GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
@@ -227,6 +237,7 @@ public class GameSessionControllerIntegrationTest {
         assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponse.toString());
     }
 
+    // TODO
     @Test
     void testThatGetNextPlayerIdAndNextTileIdReturnsTheRightNextPlayerId() throws Exception {
         GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
@@ -253,6 +264,10 @@ public class GameSessionControllerIntegrationTest {
         playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityB);
         playerEntityService.joinLobby(gameLobbyEntityA.getId(), playerEntityC);
 
+        String playerEntityAColour = playerEntityService.findPlayerById(playerEntityA.getId()).get().getPlayerColour();
+        String playerEntityBColour = playerEntityService.findPlayerById(playerEntityB.getId()).get().getPlayerColour();
+        String playerEntityCColour = playerEntityService.findPlayerById(playerEntityC.getId()).get().getPlayerColour();
+
         GameSessionDto gameSessionDtoA = TestDataUtil.createTestGameSessionDtoA(playerMapper.mapToDto(playerEntityA));
         assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
 
@@ -264,6 +279,10 @@ public class GameSessionControllerIntegrationTest {
         gameLobbyDtoA.setGameState(GameState.IN_GAME);
         gameLobbyDtoA.setLobbyAdminId(playerEntityA.getId());
         gameLobbyDtoA.setNumPlayers(3);
+
+        gameLobbyDtoA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(gameLobbyDtoA.getAvailableColours(), PlayerColour.valueOf(playerEntityAColour)));
+        gameLobbyDtoA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(gameLobbyDtoA.getAvailableColours(), PlayerColour.valueOf(playerEntityBColour)));
+        gameLobbyDtoA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsEnumListRemoveValue(gameLobbyDtoA.getAvailableColours(), PlayerColour.valueOf(playerEntityCColour)));
         gameLobbyDtoList.add(gameLobbyDtoA);
 
         gameLobbyDtoB.setLobbyAdminId(playerEntityA.getId());
@@ -290,6 +309,7 @@ public class GameSessionControllerIntegrationTest {
 
         assertThat(result.getPlayerId()).isEqualTo(expectedResponseNextPlayerId);
     }
+
     @Test
     void testThatGetNextPlayerIdAndNextTileIdReturnsTheRightNextTile() throws Exception {
         GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
@@ -395,6 +415,7 @@ public class GameSessionControllerIntegrationTest {
 
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
+
     @Test
     void testThatGameSessionControllerThrowsExceptionIfTheGameSessionIsDeleted() throws Exception {
         GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();
@@ -442,6 +463,7 @@ public class GameSessionControllerIntegrationTest {
 
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
+
     @Test
     void testThatGameSessionControllerThrowsExceptionIfTheWrongGameSessionIdIsSupplied() throws Exception {
         GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
@@ -237,7 +237,6 @@ public class GameSessionControllerIntegrationTest {
         assertThat(actualResponseGameSessionEntity).isEqualTo(expectedResponse.toString());
     }
 
-    // TODO
     @Test
     void testThatGetNextPlayerIdAndNextTileIdReturnsTheRightNextPlayerId() throws Exception {
         GameLobbyDto gameLobbyDtoA = TestDataUtil.createTestGameLobbyDtoA();

--- a/src/test/java/at/aau/serg/websocketserver/controller/PlayerControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/PlayerControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import at.aau.serg.websocketserver.domain.dto.GameLobbyDto;
 import at.aau.serg.websocketserver.domain.dto.PlayerDto;
 import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
 import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
 import at.aau.serg.websocketserver.statuscode.ErrorCode;
 import at.aau.serg.websocketserver.mapper.GameLobbyMapper;
 import at.aau.serg.websocketserver.mapper.PlayerMapper;
@@ -62,9 +63,6 @@ public class PlayerControllerIntegrationTest {
     BlockingQueue<String> messages2;
     BlockingQueue<String> messages3;
     BlockingQueue<String> messages4;
-
-
-
 
     @BeforeEach
     public void setUp() {
@@ -203,23 +201,25 @@ public class PlayerControllerIntegrationTest {
 
         String actualResponse = messages.poll(1, TimeUnit.SECONDS);
 
-        // after sending & controller processing payload:
-        // 1) assert that the test game lobby now has numPlayers = 1
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getId()).get().getNumPlayers()).isEqualTo(1);
-        // 2) assert that the test player references the test game lobby
+
+        PlayerEntity updatedPlayerEntity = playerEntityService.findPlayerById(testPlayerEntityA.getId()).get();
+        String updatedPlayerEntityColour = updatedPlayerEntity.getPlayerColour();
+
         testGameLobbyEntityA.setNumPlayers(testGameLobbyEntityA.getNumPlayers()+1);
-        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get().getGameLobbyEntity()).isEqualTo(testGameLobbyEntityA);
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(updatedPlayerEntityColour));
+        assertThat(updatedPlayerEntity.getGameLobbyEntity()).isEqualTo(testGameLobbyEntityA);
 
-
-        // expected response: updated playerDto with the Lobby, which itself should also be updated to have incremented numPlayers
         testGameLobbyDtoA.setNumPlayers(testGameLobbyDtoA.getNumPlayers()+1);
         testPlayerDtoA.setGameLobbyId(testGameLobbyDtoA.getId());
+
+        // Randomness-Workaround for playerColour
+        testPlayerDtoA.setPlayerColour(PlayerColour.valueOf(updatedPlayerEntityColour));
+
         var expectedResponse = objectMapper.writeValueAsString(testPlayerDtoA);
 
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
-
-
 
     @Test
     void testThatJoinLobbySuccessfullySendsUpdatedLobbyListToTopic() throws Exception {
@@ -256,7 +256,9 @@ public class PlayerControllerIntegrationTest {
         // 1) assert that the test game lobby now has numPlayers = 1
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getId()).get().getNumPlayers()).isEqualTo(1);
         // 2) assert that the test player references the test game lobby
+        PlayerEntity updatedPlayerEntity = playerEntityService.findPlayerById(testPlayerEntityA.getId()).get();
         testGameLobbyEntityA.setNumPlayers(testGameLobbyEntityA.getNumPlayers()+1);
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(updatedPlayerEntity.getPlayerColour()));
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get().getGameLobbyEntity()).isEqualTo(testGameLobbyEntityA);
 
 
@@ -303,7 +305,9 @@ public class PlayerControllerIntegrationTest {
         // 1) assert that the test game lobby now has numPlayers = 1
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getId()).get().getNumPlayers()).isEqualTo(1);
         // 2) assert that the test player references the test game lobby
+        PlayerEntity updatedPlayerEntity = playerEntityService.findPlayerById(testPlayerEntityA.getId()).get();
         testGameLobbyEntityA.setNumPlayers(testGameLobbyEntityA.getNumPlayers()+1);
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(updatedPlayerEntity.getPlayerColour()));
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get().getGameLobbyEntity()).isEqualTo(testGameLobbyEntityA);
 
 
@@ -315,7 +319,7 @@ public class PlayerControllerIntegrationTest {
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
 
-
+    // TODO
     // DONE: test 3 sessions in parallel (queue, topic/lobby-list, topic/lobby-$id)
     /**
      * Test if 3 sessions at the same time all receive their respective responses:
@@ -366,13 +370,16 @@ public class PlayerControllerIntegrationTest {
         // 1) assert that the test game lobby now has numPlayers = 1
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getId()).get().getNumPlayers()).isEqualTo(1);
         // 2) assert that the test player references the test game lobby
+        PlayerEntity updatedPlayerEntity = playerEntityService.findPlayerById(testPlayerEntityA.getId()).get();
         testGameLobbyEntityA.setNumPlayers(testGameLobbyEntityA.getNumPlayers()+1);
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(updatedPlayerEntity.getPlayerColour()));
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get().getGameLobbyEntity()).isEqualTo(testGameLobbyEntityA);
 
 
-        // expected response: updated playerDto with the Lobby, which itself should also be updated to have incremented numPlayers
+        // expected response: updated playerDto with the Lobby, which itself should also be updated to have incremented numPlayers, and the playerColour should be set
         testGameLobbyDtoA.setNumPlayers(testGameLobbyDtoA.getNumPlayers()+1);
         testPlayerDtoA.setGameLobbyId(testGameLobbyDtoA.getId());
+        testPlayerDtoA.setPlayerColour(PlayerColour.valueOf(updatedPlayerEntity.getPlayerColour()));
         var expectedResponse = objectMapper.writeValueAsString(testPlayerDtoA);
         assertThat(actualResponse).isEqualTo(expectedResponse);
 
@@ -441,13 +448,16 @@ public class PlayerControllerIntegrationTest {
         // 1) assert that the test game lobby now has numPlayers = 1
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getId()).get().getNumPlayers()).isEqualTo(1);
         // 2) assert that the test player references the test game lobby
+        PlayerEntity updatedPlayerEntity = playerEntityService.findPlayerById(testPlayerEntityA.getId()).get();
         testGameLobbyEntityA.setNumPlayers(testGameLobbyEntityA.getNumPlayers()+1);
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(updatedPlayerEntity.getPlayerColour()));
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get().getGameLobbyEntity()).isEqualTo(testGameLobbyEntityA);
 
 
         // expected response: updated playerDto with the Lobby, which itself should also be updated to have incremented numPlayers
         testGameLobbyDtoA.setNumPlayers(testGameLobbyDtoA.getNumPlayers()+1);
         testPlayerDtoA.setGameLobbyId(testGameLobbyDtoA.getId());
+        testPlayerDtoA.setPlayerColour(PlayerColour.valueOf(updatedPlayerEntity.getPlayerColour()));
         var expectedResponse = objectMapper.writeValueAsString(testPlayerDtoA);
         assertThat(actualResponse).isEqualTo(expectedResponse);
 
@@ -802,14 +812,15 @@ public class PlayerControllerIntegrationTest {
 
         // Populate the database with testPlayerEntityA who joins testGameLobbyEntityA:
         PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        testPlayerEntityA.setPlayerColour(PlayerColour.RED.name());
         GameLobbyEntity testGameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(PlayerColour.RED.name()));
         testPlayerEntityA.setGameLobbyEntity(testGameLobbyEntityA);
 
         PlayerEntity testPlayerEntityB = TestDataUtil.createTestPlayerEntityB(null);
         testPlayerEntityB.setGameLobbyEntity(testGameLobbyEntityA);
 
         StompSession session = initStompSession("/user/queue/response", messages);
-
 
         testGameLobbyEntityA.setNumPlayers(2);
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId())).isEmpty();
@@ -833,14 +844,20 @@ public class PlayerControllerIntegrationTest {
 
         String actualResponse = messages.poll(1, TimeUnit.SECONDS);
 
+        PlayerEntity updatedTestPlayerEntityA = playerEntityService.findPlayerById(testPlayerEntityA.getId()).get();
+
         // after controller method call:
         // assert that the player and game lobby entities in the database have updated as expected
         testGameLobbyEntityA.setNumPlayers(1);
+        testGameLobbyEntityA.getAvailableColours().add(testPlayerEntityA.getPlayerColour());
         assertThat(gameLobbyEntityService.findById(testPlayerDtoA.getId()).get()).isEqualTo(testGameLobbyEntityA);
+
         testPlayerEntityA.setGameLobbyEntity(null);
-        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
+        testPlayerEntityA.setPlayerColour(null);
+        assertThat(updatedTestPlayerEntityA).isEqualTo(testPlayerEntityA);
 
         testPlayerDtoA.setGameLobbyId(null);
+        testPlayerDtoA.setPlayerColour(null);
         var expectedResponse = objectMapper.writeValueAsString(testPlayerDtoA);
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
@@ -850,7 +867,10 @@ public class PlayerControllerIntegrationTest {
 
         // Populate the database with testPlayerEntityA who joins testGameLobbyEntityA:
         PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        testPlayerEntityA.setPlayerColour(PlayerColour.RED.name());
+
         GameLobbyEntity testGameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(PlayerColour.RED.name()));
         testPlayerEntityA.setGameLobbyEntity(testGameLobbyEntityA);
         testGameLobbyEntityA.setLobbyAdminId(testGameLobbyEntityA.getId());
 
@@ -887,9 +907,11 @@ public class PlayerControllerIntegrationTest {
         testGameLobbyEntityA.setNumPlayers(1);
         // new: update lobbyCreator id
         testGameLobbyEntityA.setLobbyAdminId(testPlayerEntityB.getId());
+        testGameLobbyEntityA.getAvailableColours().add(testPlayerEntityA.getPlayerColour());
         assertThat(gameLobbyEntityService.findById(testPlayerDtoA.getId()).get()).isEqualTo(testGameLobbyEntityA);
 
         testPlayerEntityA.setGameLobbyEntity(null);
+        testPlayerEntityA.setPlayerColour(null);
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
 
         testPlayerDtoA.setGameLobbyId(null);
@@ -902,13 +924,17 @@ public class PlayerControllerIntegrationTest {
 
         // Populate the database with testPlayerEntityA who joins testGameLobbyEntityA:
         PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+
         GameLobbyEntity testGameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(PlayerColour.RED.name()));
         testPlayerEntityA.setGameLobbyEntity(testGameLobbyEntityA);
 
         // testPlayerA is the lobby creator:
         testGameLobbyEntityA.setLobbyAdminId(testGameLobbyEntityA.getId());
 
         PlayerEntity testPlayerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        testPlayerEntityB.setPlayerColour(PlayerColour.YELLOW.name());
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(testGameLobbyEntityA.getAvailableColours(), PlayerColour.YELLOW.name()));
         testPlayerEntityB.setGameLobbyEntity(testGameLobbyEntityA);
 
         StompSession session = initStompSession("/topic/lobby-" + testGameLobbyEntityA.getId() + "/update", messages);
@@ -930,7 +956,6 @@ public class PlayerControllerIntegrationTest {
 
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getLobbyAdminId()).get().getLobbyAdminId()).isEqualTo(testPlayerEntityA.getId());
 
-
         // create payload string (player who is not a lobbyCreator)
         PlayerDto testPlayerDtoB = playerMapper.mapToDto(testPlayerEntityB);
         String payload = objectMapper.writeValueAsString(testPlayerDtoB);
@@ -942,9 +967,12 @@ public class PlayerControllerIntegrationTest {
         // after controller method call:
         // assert that the player and game lobby entities in the database have updated as expected
         testGameLobbyEntityA.setNumPlayers(1);
+        testGameLobbyEntityA.getAvailableColours().add(testPlayerEntityB.getPlayerColour());
+        GameLobbyEntity test = gameLobbyEntityService.findById(testPlayerEntityA.getId()).get();
         assertThat(gameLobbyEntityService.findById(testPlayerEntityA.getId()).get()).isEqualTo(testGameLobbyEntityA);
 
         testPlayerEntityB.setGameLobbyEntity(null);
+        testPlayerEntityB.setPlayerColour(null);
         assertThat(playerEntityService.findPlayerById(testPlayerEntityB.getId()).get()).isEqualTo(testPlayerEntityB);
 
         assertThat(gameLobbyEntityService.findById(testGameLobbyEntityA.getLobbyAdminId()).get().getLobbyAdminId()).isEqualTo(testPlayerEntityA.getId());
@@ -953,15 +981,22 @@ public class PlayerControllerIntegrationTest {
         var expectedResponse = objectMapper.writeValueAsString(testGameLobbyEntityA);
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
+
     @Test
     void testThatLeaveLobbyWithMoreThanOnePlayerSuccessfullyRemovesPlayerFromGameLobbyAndReturnsUpdatedListOfLobbies() throws Exception {
 
         // Populate the database with testPlayerEntityA who joins testGameLobbyEntityA:
         PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        testPlayerEntityA.setPlayerColour(PlayerColour.RED.name());
+
         GameLobbyEntity testGameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(PlayerColour.RED.name()));
         testPlayerEntityA.setGameLobbyEntity(testGameLobbyEntityA);
 
         PlayerEntity testPlayerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        testPlayerEntityB.setPlayerColour(PlayerColour.YELLOW.name());
+        List<String> availableColours = testGameLobbyEntityA.getAvailableColours();
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(availableColours, PlayerColour.YELLOW.name()));
         testPlayerEntityB.setGameLobbyEntity(testGameLobbyEntityA);
 
         StompSession session = initStompSession("/topic/lobby-list", messages);
@@ -992,8 +1027,10 @@ public class PlayerControllerIntegrationTest {
         // after controller method call:
         // assert that the player and game lobby entities in the database have updated as expected
         testGameLobbyEntityA.setNumPlayers(1);
+        testGameLobbyEntityA.getAvailableColours().add(testPlayerEntityA.getPlayerColour());
         assertThat(gameLobbyEntityService.findById(testPlayerDtoA.getId()).get()).isEqualTo(testGameLobbyEntityA);
         testPlayerEntityA.setGameLobbyEntity(null);
+        testPlayerEntityA.setPlayerColour(null);
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
         testPlayerDtoA.setGameLobbyId(null);
 
@@ -1006,11 +1043,18 @@ public class PlayerControllerIntegrationTest {
 
         // Populate the database with testPlayerEntityA who joins testGameLobbyEntityA:
         PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        testPlayerEntityA.setPlayerColour(PlayerColour.RED.name());
+
         GameLobbyEntity testGameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(PlayerColour.RED.name()));
         testPlayerEntityA.setGameLobbyEntity(testGameLobbyEntityA);
 
         PlayerEntity testPlayerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+        testPlayerEntityB.setPlayerColour(PlayerColour.YELLOW.name());
         testPlayerEntityB.setGameLobbyEntity(testGameLobbyEntityA);
+
+        List<String> availableColours = testGameLobbyEntityA.getAvailableColours();
+        testGameLobbyEntityA.setAvailableColours(TestDataUtil.getTestPlayerColoursAsStringListRemoveValue(availableColours, PlayerColour.YELLOW.name()));
 
         StompSession session = initStompSession("/topic/lobby-" + testGameLobbyEntityA.getId(), messages);
 
@@ -1040,8 +1084,10 @@ public class PlayerControllerIntegrationTest {
         // after controller method call:
         // assert that the player and game lobby entities in the database have updated as expected
         testGameLobbyEntityA.setNumPlayers(1);
+        testGameLobbyEntityA.getAvailableColours().add(testPlayerEntityA.getPlayerColour());
         assertThat(gameLobbyEntityService.findById(testPlayerDtoA.getId()).get()).isEqualTo(testGameLobbyEntityA);
         testPlayerEntityA.setGameLobbyEntity(null);
+        testPlayerEntityA.setPlayerColour(null);
         assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
         testPlayerDtoA.setGameLobbyId(null);
 
@@ -1172,18 +1218,18 @@ public class PlayerControllerIntegrationTest {
     @Test
     void testThatDeletePlayerInLobbySuccessfullyRemovesPlayerFromLobbyAndDeletesExistingPlayer() throws Exception {
         GameLobbyEntity gameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
-        GameLobbyDto gameLobbyDtoA = gameLobbyMapper.mapToDto(gameLobbyEntityA);
-        gameLobbyDtoA.setNumPlayers(2);
-
         StompSession session = initStompSessionWithSecondTopic("/user/queue/response", "/topic/lobby-" + gameLobbyEntityA.getId(), messages, messages2);
 
         PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
         PlayerEntity testPlayerEntityB = TestDataUtil.createTestPlayerEntityB(null);
 
+        GameLobbyDto gameLobbyDtoA = gameLobbyMapper.mapToDto(gameLobbyEntityA);
+        gameLobbyDtoA.setNumPlayers(2);
+
         PlayerDto playerDtoB = playerMapper.mapToDto(testPlayerEntityB);
         playerDtoB.setGameLobbyId(gameLobbyEntityA.getId());
         List<PlayerDto> playerDtoList = new ArrayList<>();
-        playerDtoList.add(playerDtoB);
+
 
         playerEntityService.createPlayer(testPlayerEntityA);
         playerEntityService.createPlayer(testPlayerEntityB);
@@ -1196,10 +1242,16 @@ public class PlayerControllerIntegrationTest {
         playerEntityService.joinLobby(gameLobbyEntityA.getId(), testPlayerEntityA);
         playerEntityService.joinLobby(gameLobbyEntityA.getId(), testPlayerEntityB);
 
+        //GameLobbyEntity test = gameLobbyEntityService.findById(gameLobbyEntityA.getId()).get();
+
         PlayerDto testPlayerDtoA = playerMapper.mapToDto(testPlayerEntityA);
         session.send("/app/player-delete", objectMapper.writeValueAsString(testPlayerDtoA));
 
         String actualResponseTopic1 = messages.poll(1, TimeUnit.SECONDS);
+
+        // Randomness-Workaround
+        playerDtoB.setPlayerColour(PlayerColour.valueOf(playerEntityService.findPlayerById(testPlayerEntityB.getId()).get().getPlayerColour()));
+        playerDtoList.add(playerDtoB);
 
         String expectedResponseTopic2 = objectMapper.writeValueAsString(playerDtoList);
         String actualResponseTopic2 = messages2.poll(1, TimeUnit.SECONDS);

--- a/src/test/java/at/aau/serg/websocketserver/controller/PlayerControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/PlayerControllerIntegrationTest.java
@@ -319,7 +319,6 @@ public class PlayerControllerIntegrationTest {
         assertThat(actualResponse).isEqualTo(expectedResponse);
     }
 
-    // TODO
     // DONE: test 3 sessions in parallel (queue, topic/lobby-list, topic/lobby-$id)
     /**
      * Test if 3 sessions at the same time all receive their respective responses:


### PR DESCRIPTION
A player is now uniquely assigned one of five available colors (which are stored in the gamelobby object) when:
- creating and joining a lobby
- joining a lobby
When this happens the assigned color is removed from the available colors in the game lobby object

When leaving the lobby the color is removed from the player and returned back to the list of available colors