### PR TITLE
Amadeo lobby list update at game start

### DIFF
--- a/src/main/java/at/aau/serg/websocketserver/controller/GameSessionController.java
+++ b/src/main/java/at/aau/serg/websocketserver/controller/GameSessionController.java
@@ -69,6 +69,8 @@ public class GameSessionController {
         List<GameLobbyDto> gameLobbyDtoList = HelperMethods.getGameLobbyDtoList(gameLobbyEntityService, gameLobbyMapper);
         this.template.convertAndSend("/topic/lobby-" + gameLobbyId + "/game-start", objectMapper.writeValueAsString(gameSessionEntity.getId()));
 
+        this.template.convertAndSend("/topic/lobby-list", objectMapper.writeValueAsString(gameLobbyDtoList));
+
         return objectMapper.writeValueAsString(gameLobbyDtoList);
     }
 

--- a/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/controller/GameSessionControllerIntegrationTest.java
@@ -128,13 +128,19 @@ public class GameSessionControllerIntegrationTest {
         assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isEmpty();
 
         StompSession session = initStompSession("/topic/lobby-" + gameLobbyDtoA.getId() + "/game-start", messages);
+        StompSession session2 = initStompSession("/topic/lobby-list", messages2);
         session.send("/app/game-start", gameLobbyDtoA.getId() + "");
 
         String actualResponse = messages.poll(1, TimeUnit.SECONDS);
+        String actualResponse2 = messages2.poll(1, TimeUnit.SECONDS);
 
         assertThat(gameSessionEntityService.findById(gameSessionDtoA.getId())).isPresent();
         assertThat(actualResponse).isEqualTo(gameSessionDtoA.getId() + "");
+
+        assertThat(actualResponse2).isNotNull();
+
     }
+
 
     @Test
     void testThatCreateGameSessionReturnsUpdatedLobbyListToQueue() throws Exception {


### PR DESCRIPTION
Add the message that is sent to the /topic/lobby-list when the game starts. This is needed for the lobbyListActivity, where the lobbies are shown. This message makes sure, that the lobby, that just entered the game is not shown anymore in the available lobbies lobbyList.

I also added the tests to cover this added line.