### PR TITLE
Updated player delete logic

### DIFF
--- a/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
+++ b/src/main/java/at/aau/serg/websocketserver/controller/PlayerController.java
@@ -2,7 +2,6 @@ package at.aau.serg.websocketserver.controller;
 
 import at.aau.serg.websocketserver.domain.dto.GameLobbyDto;
 import at.aau.serg.websocketserver.domain.dto.PlayerDto;
-import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
 import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
 import at.aau.serg.websocketserver.mapper.GameLobbyMapper;
 import at.aau.serg.websocketserver.mapper.PlayerMapper;
@@ -12,7 +11,7 @@ import at.aau.serg.websocketserver.statuscode.ErrorCode;
 import at.aau.serg.websocketserver.statuscode.ResponseCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityExistsException;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -49,12 +48,12 @@ public class PlayerController {
 
     @MessageMapping("/player-create")
     @SendToUser("/queue/response")
-    public String handleCreatePlayer(String playerDtoJson) throws JsonProcessingException {
+    public String handleCreatePlayer(String playerDtoJson,@Header("simpSessionId") String sessionId) throws JsonProcessingException {
 
         // read in the JSON String and convert to PlayerDTO Object
         PlayerDto playerDto = objectMapper.readValue(playerDtoJson, PlayerDto.class);
 
-        PlayerEntity createdPlayerEntity = playerEntityService.createPlayer(playerMapper.mapToEntity(playerDto));
+        PlayerEntity createdPlayerEntity = playerEntityService.createPlayer(playerMapper.mapToEntity(playerDto), sessionId);
         // return the DTO of the created player
         return objectMapper.writeValueAsString(playerMapper.mapToDto(createdPlayerEntity));
     }
@@ -237,13 +236,13 @@ public class PlayerController {
         }
     }
 
-    // TODO: handle deletion of player inside a lobby properly?
+    // TODO: Delete
     @MessageMapping("/player-delete")
     @SendToUser("/queue/response")
     public String handleDeletePlayer(String playerDtoJson) throws JsonProcessingException {
         PlayerDto playerDto = objectMapper.readValue(playerDtoJson, PlayerDto.class);
 
-        playerEntityService.deletePlayer(playerDto.getId());
+        /*playerEntityService.deletePlayer(playerDto.getId());
 
         Optional<PlayerEntity> playerEntity = playerEntityService.findPlayerById(playerDto.getId());
         if (playerEntity.isPresent()) {
@@ -267,7 +266,7 @@ public class PlayerController {
                         objectMapper.writeValueAsString(getGameLobbyDtoList(gameLobbyEntityService, gameLobbyMapper))
                 );
             }
-        }
+        }*/
 
         return ResponseCode.RESPONSE_103.getCode();
     }

--- a/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerDto.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/dto/PlayerDto.java
@@ -14,6 +14,7 @@ public class PlayerDto {
     private Long id;
 
     private String username;
+    private String sessionId;
 
     private Long gameLobbyId;
     private PlayerColour playerColour;

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/PlayerEntity.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/PlayerEntity.java
@@ -19,6 +19,8 @@ public class PlayerEntity {
 
     private String username;
 
+    private String sessionId;
+
     // 0..1 : n relationship betw. lobby and player
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name="gamelobby_id")

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/GameSessionEntityRepository.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/GameSessionEntityRepository.java
@@ -2,7 +2,14 @@ package at.aau.serg.websocketserver.domain.entity.repository;
 
 
 import at.aau.serg.websocketserver.domain.entity.GameSessionEntity;
+import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface GameSessionEntityRepository extends JpaRepository<GameSessionEntity, Long> {
+    @Query(value = "SELECT * FROM GAME_SESSION g WHERE :playerId = ANY (g.player_ids) LIMIT 1", nativeQuery = true)
+    Optional<GameSessionEntity> findByPlayerId(@Param("playerId") Long playerId);
 }

--- a/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/PlayerEntityRepository.java
+++ b/src/main/java/at/aau/serg/websocketserver/domain/entity/repository/PlayerEntityRepository.java
@@ -4,6 +4,7 @@ import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PlayerEntityRepository extends JpaRepository<PlayerEntity, Long> {
 
@@ -13,4 +14,6 @@ public interface PlayerEntityRepository extends JpaRepository<PlayerEntity, Long
     List<PlayerEntity> findPlayerEntitiesByGameLobbyEntity_Id(Long id);
 
     List<PlayerEntity> findPlayerEntitiesByUsername(String username);
+
+    Optional<PlayerEntity> findBySessionId(String sessionId);
 }

--- a/src/main/java/at/aau/serg/websocketserver/service/PlayerEntityService.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/PlayerEntityService.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 public interface PlayerEntityService {
 
     PlayerEntity createPlayer(PlayerEntity playerEntity) throws EntityExistsException;
+    PlayerEntity createPlayer(PlayerEntity playerEntity, String sessionId) throws EntityExistsException;
     PlayerEntity updateUsername(PlayerEntity playerEntity) throws EntityNotFoundException;
     PlayerEntity joinLobby(Long gameLobbyId, PlayerEntity playerEntity) throws RuntimeException;
     List<PlayerEntity> getAllPlayersForLobby(Long gameLobbyId);
@@ -19,4 +20,5 @@ public interface PlayerEntityService {
     boolean exists(Long id);
 
     Optional<PlayerEntity> findPlayerById(Long id);
+    Optional<PlayerEntity> findPlayerBySessionId(String sessionId);
 }

--- a/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
+++ b/src/main/java/at/aau/serg/websocketserver/service/impl/PlayerEntityServiceImpl.java
@@ -47,10 +47,14 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
         gameLobbyEntity.setAvailableColours(colours);
     }
 
-    // @Dominik: slightly different approach: expose only entity objects to the service
+    // Only used for integration tests
     @Override
     public PlayerEntity createPlayer(PlayerEntity playerEntity) throws EntityExistsException {
+        return createPlayer(playerEntity, null);
+    }
 
+    @Override
+    public PlayerEntity createPlayer(PlayerEntity playerEntity, String sessionId) throws EntityExistsException {
         // check if player with id already exists
         if(playerEntity.getId() != null && playerEntityRepository.findById(playerEntity.getId()).isPresent()) {
             throw new EntityExistsException(ErrorCode.ERROR_2002.getCode());
@@ -61,6 +65,7 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
             throw new EntityExistsException(ErrorCode.ERROR_2003.getCode());
         }
 
+        if(sessionId != null && !sessionId.isEmpty()) playerEntity.setSessionId(sessionId);
         return playerEntityRepository.save(playerEntity);
     }
 
@@ -191,5 +196,10 @@ public class PlayerEntityServiceImpl implements PlayerEntityService {
     @Override
     public Optional<PlayerEntity> findPlayerById(Long id) {
         return playerEntityRepository.findById(id);
+    }
+
+    @Override
+    public Optional<PlayerEntity> findPlayerBySessionId(String sessionId) {
+        return playerEntityRepository.findBySessionId(sessionId);
     }
 }

--- a/src/main/java/at/aau/serg/websocketserver/websocket/ClientDisconnectListener.java
+++ b/src/main/java/at/aau/serg/websocketserver/websocket/ClientDisconnectListener.java
@@ -1,0 +1,74 @@
+package at.aau.serg.websocketserver.websocket;
+
+import at.aau.serg.websocketserver.domain.dto.PlayerDto;
+import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
+import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
+import at.aau.serg.websocketserver.mapper.GameLobbyMapper;
+import at.aau.serg.websocketserver.mapper.PlayerMapper;
+import at.aau.serg.websocketserver.service.GameLobbyEntityService;
+import at.aau.serg.websocketserver.service.PlayerEntityService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.Optional;
+
+import static at.aau.serg.websocketserver.controller.helper.HelperMethods.getGameLobbyDtoList;
+import static at.aau.serg.websocketserver.controller.helper.HelperMethods.getPlayerDtosInLobbyList;
+
+@Component
+public class ClientDisconnectListener {
+    private final SimpMessagingTemplate template;
+    private final PlayerEntityService playerEntityService;
+    private final GameLobbyEntityService gameLobbyEntityService;
+    private final ObjectMapper objectMapper;
+    private final PlayerMapper playerMapper;
+    private final GameLobbyMapper gameLobbyMapper;
+
+    public ClientDisconnectListener(SimpMessagingTemplate template, PlayerEntityService playerEntityServiceImpl, GameLobbyEntityService gameLobbyEntityService, ObjectMapper objectMapper, PlayerMapper playerMapper, GameLobbyMapper gameLobbyMapper) {
+        this.template = template;
+        this.playerEntityService = playerEntityServiceImpl;
+        this.gameLobbyEntityService = gameLobbyEntityService;
+        this.objectMapper = objectMapper;
+        this.playerMapper = playerMapper;
+        this.gameLobbyMapper = gameLobbyMapper;
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) throws JsonProcessingException {
+        SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+
+        Optional<PlayerEntity> playerEntityOptional = playerEntityService.findPlayerBySessionId(sessionId);
+        if(playerEntityOptional.isPresent()) {
+            PlayerEntity playerEntity = playerEntityOptional.get();
+            PlayerDto playerDto = playerMapper.mapToDto(playerEntity);
+
+            playerEntityService.deletePlayer(playerDto.getId());
+
+            // Update logic if a player was part of a lobby
+            if(playerDto.getGameLobbyId() != null) {
+                Optional<GameLobbyEntity> gameLobbyEntityOptional = gameLobbyEntityService.findById(playerDto.getGameLobbyId());
+                if(gameLobbyEntityOptional.isPresent()) {
+                    GameLobbyEntity gameLobbyEntity = gameLobbyEntityOptional.get();
+                    // send response to: /topic/lobby-$id --> updated list of players in lobby (later with response code: 201)
+                    this.template.convertAndSend(
+                            "/topic/lobby-" + gameLobbyEntity.getId(),
+                            objectMapper.writeValueAsString(getPlayerDtosInLobbyList(gameLobbyEntity.getId(), gameLobbyEntityService, playerEntityService, playerMapper))
+                    );
+                } else {
+                    // send response to: /topic/lobby-list --> updated list of lobbies (later with response code 301)
+                    this.template.convertAndSend(
+                            "/topic/lobby-list",
+                            objectMapper.writeValueAsString(getGameLobbyDtoList(gameLobbyEntityService, gameLobbyMapper))
+                    );
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/java/at/aau/serg/websocketserver/websocket/ClientDisconnectListener.java
+++ b/src/main/java/at/aau/serg/websocketserver/websocket/ClientDisconnectListener.java
@@ -87,10 +87,9 @@ public class ClientDisconnectListener {
                 gameSessionEntityRepository.save(gameSessionEntity);
 
                 // Check if gameSession can be terminated
-                if (playerIds.isEmpty()) {
+                if (playerIds.size() == 1) {
                     gameSessionEntityService.terminateGameSession(gameSessionEntity.getId());
                 }
-
             }
 
         }

--- a/src/main/java/at/aau/serg/websocketserver/websocket/WebSocketBrokerConfig.java
+++ b/src/main/java/at/aau/serg/websocketserver/websocket/WebSocketBrokerConfig.java
@@ -1,4 +1,4 @@
-package at.aau.serg.websocketserver.websocketConfig;
+package at.aau.serg.websocketserver.websocket;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;

--- a/src/test/java/at/aau/serg/websocketserver/websocket/ClientDisconnectListenerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketserver/websocket/ClientDisconnectListenerIntegrationTest.java
@@ -1,0 +1,205 @@
+package at.aau.serg.websocketserver.websocket;
+
+import at.aau.serg.websocketserver.TestDataUtil;
+import at.aau.serg.websocketserver.demo.websocket.StompFrameHandlerClientImpl;
+import at.aau.serg.websocketserver.domain.dto.GameLobbyDto;
+import at.aau.serg.websocketserver.domain.dto.PlayerDto;
+import at.aau.serg.websocketserver.domain.entity.GameLobbyEntity;
+import at.aau.serg.websocketserver.domain.entity.PlayerEntity;
+import at.aau.serg.websocketserver.domain.pojo.PlayerColour;
+import at.aau.serg.websocketserver.mapper.GameLobbyMapper;
+import at.aau.serg.websocketserver.mapper.PlayerMapper;
+import at.aau.serg.websocketserver.service.GameLobbyEntityService;
+import at.aau.serg.websocketserver.service.PlayerEntityService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(SpringExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class ClientDisconnectListenerIntegrationTest {
+
+    PlayerEntityService playerEntityService;
+    GameLobbyEntityService gameLobbyEntityService;
+    PlayerMapper playerMapper;
+    GameLobbyMapper gameLobbyMapper;
+    ObjectMapper objectMapper;
+    ApplicationEventPublisher eventPublisher;
+
+    @LocalServerPort
+    private int port;
+    private final String WEBSOCKET_URI = "ws://localhost:%d/websocket-broker";
+    BlockingQueue<String> messages;
+
+    @Autowired
+    public ClientDisconnectListenerIntegrationTest(PlayerEntityService playerEntityService, GameLobbyEntityService gameLobbyEntityService, PlayerMapper playerMapper, GameLobbyMapper gameLobbyMapper, ObjectMapper objectMapper, ApplicationEventPublisher eventPublisher) {
+        this.playerEntityService = playerEntityService;
+        this.gameLobbyEntityService = gameLobbyEntityService;
+        this.playerMapper = playerMapper;
+        this.gameLobbyMapper = gameLobbyMapper;
+        this.objectMapper = objectMapper;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @BeforeEach
+    public void setUp() {
+        messages = new LinkedBlockingDeque<>();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        messages = null;
+    }
+
+    @Test
+    void testThatDisconnectWithoutLobbySuccessfullyDeletesExistingPlayer() throws Exception {
+        StompSession session = initStompSession();
+
+        PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        playerEntityService.createPlayer(testPlayerEntityA, session.getSessionId());
+
+        // assert that player currently exists in database
+        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
+
+        // Simulate a session disconnect event and publish it
+        SessionDisconnectEvent event = createSessionDisconnectEvent(this,session.getSessionId());
+        eventPublisher.publishEvent(event);
+
+        // assert that player no longer exists in database
+        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId())).isEmpty();
+    }
+
+    @Test
+    void testThatDisconnectWithPlayerInLobbySuccessfullyRemovesPlayerFromLobbyAndDeletesExistingPlayer() throws Exception {
+        GameLobbyEntity gameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
+        StompSession session = initStompSession();
+        session.subscribe("/topic/lobby-" + gameLobbyEntityA.getId(), new StompFrameHandlerClientImpl(messages));
+
+        PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+        PlayerEntity testPlayerEntityB = TestDataUtil.createTestPlayerEntityB(null);
+
+        GameLobbyDto gameLobbyDtoA = gameLobbyMapper.mapToDto(gameLobbyEntityA);
+        gameLobbyDtoA.setNumPlayers(2);
+
+        PlayerDto playerDtoB = playerMapper.mapToDto(testPlayerEntityB);
+        playerDtoB.setGameLobbyId(gameLobbyEntityA.getId());
+        List<PlayerDto> playerDtoList = new ArrayList<>();
+
+        playerEntityService.createPlayer(testPlayerEntityA, session.getSessionId());
+        playerEntityService.createPlayer(testPlayerEntityB);
+        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
+        assertThat(playerEntityService.findPlayerById(testPlayerEntityB.getId()).get()).isEqualTo(testPlayerEntityB);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        assertThat(gameLobbyEntityService.findById(gameLobbyEntityA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), testPlayerEntityA);
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), testPlayerEntityB);
+
+        // Simulate a session disconnect event and publish it
+        SessionDisconnectEvent event = createSessionDisconnectEvent(this,session.getSessionId());
+        eventPublisher.publishEvent(event);
+
+        // Randomness-Workaround
+        playerDtoB.setPlayerColour(PlayerColour.valueOf(playerEntityService.findPlayerById(testPlayerEntityB.getId()).get().getPlayerColour()));
+        playerDtoList.add(playerDtoB);
+
+        String expectedResponse = objectMapper.writeValueAsString(playerDtoList);
+        String actualResponse = messages.poll(1, TimeUnit.SECONDS);
+
+        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId())).isEmpty();
+        assertThat(gameLobbyEntityService.findById(gameLobbyEntityA.getId())).isPresent();
+
+        List<PlayerEntity> playerEntityList = playerEntityService.getAllPlayersForLobby(gameLobbyEntityA.getId());
+        gameLobbyDtoA.setNumPlayers(gameLobbyDtoA.getNumPlayers() - 1);
+
+        assertThat(playerEntityList.size()).isEqualTo(gameLobbyDtoA.getNumPlayers());
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void testThatDisconnectWithPlayerOnlyPlayerInLobbySuccessfullyDeletesLobbyAndPlayer() throws Exception {
+        GameLobbyEntity gameLobbyEntityA = TestDataUtil.createTestGameLobbyEntityA();
+        GameLobbyEntity gameLobbyEntityB = TestDataUtil.createTestGameLobbyEntityB();
+        GameLobbyDto gameLobbyDtoA = gameLobbyMapper.mapToDto(gameLobbyEntityA);
+        GameLobbyDto gameLobbyDtoB = gameLobbyMapper.mapToDto(gameLobbyEntityB);
+        gameLobbyDtoA.setNumPlayers(2);
+
+        List<GameLobbyDto> gameLobbyDtoList = new ArrayList<>();
+        gameLobbyDtoList.add(gameLobbyDtoB);
+
+        StompSession session = initStompSession();
+        session.subscribe("/topic/lobby-list", new StompFrameHandlerClientImpl(messages));
+
+        PlayerEntity testPlayerEntityA = TestDataUtil.createTestPlayerEntityA(null);
+
+        playerEntityService.createPlayer(testPlayerEntityA, session.getSessionId());
+        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId()).get()).isEqualTo(testPlayerEntityA);
+
+        gameLobbyEntityService.createLobby(gameLobbyEntityA);
+        gameLobbyEntityService.createLobby(gameLobbyEntityB);
+        assertThat(gameLobbyEntityService.findById(gameLobbyEntityA.getId())).isPresent();
+
+        playerEntityService.joinLobby(gameLobbyEntityA.getId(), testPlayerEntityA);
+
+        // Simulate a session disconnect event and publish it
+        SessionDisconnectEvent event = createSessionDisconnectEvent(this,session.getSessionId());
+        eventPublisher.publishEvent(event);
+
+        String expectedResponse = objectMapper.writeValueAsString(gameLobbyDtoList);
+        String actualResponse = messages.poll(1, TimeUnit.SECONDS);
+
+        assertThat(playerEntityService.findPlayerById(testPlayerEntityA.getId())).isEmpty();
+        assertThat(gameLobbyEntityService.findById(gameLobbyEntityA.getId())).isEmpty();
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    private SessionDisconnectEvent createSessionDisconnectEvent(Object source, String sessionId) {
+        SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
+        headerAccessor.setSessionId(sessionId);
+
+        Message<byte[]> message = MessageBuilder.withPayload(new byte[0])
+                .setHeaders(headerAccessor)
+                .build();
+        return new SessionDisconnectEvent(source, message, sessionId, CloseStatus.NORMAL);
+    }
+
+    public StompSession initStompSession() throws Exception {
+        WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new StringMessageConverter());
+
+        StompSession session = stompClient.connectAsync(String.format(WEBSOCKET_URI, port),
+                        new StompSessionHandlerAdapter() {
+                        })
+                .get(1, TimeUnit.SECONDS);
+
+        return session;
+    }
+}


### PR DESCRIPTION
What is new:
- A event listener now listens to session disconnects
- When a session is disconnected a player with the matching session id is queried
- The player is deleted and removed from the lobby and the gamesession
- The lobby is deleted if the player was the last one in it
- The game-session is terminated if there is no player left